### PR TITLE
fix: historian livelock starves pending drops in active sessions

### DIFF
--- a/packages/plugin/src/hooks/magic-context/compartment-runner-incremental.ts
+++ b/packages/plugin/src/hooks/magic-context/compartment-runner-incremental.ts
@@ -56,7 +56,9 @@ import { clearInjectionCache, renderMemoryBlock } from "./inject-compartments";
 import { onNoteTrigger } from "./note-nudger";
 import {
     createDefaultBoundarySnapshotForTests,
+    hasRunnableCompartmentWindow,
     recordHighPressureNoEligibleHead,
+    resolveOpenCodeProtectedTailBoundary,
     selectPerRunCap,
     validateBoundarySnapshot,
 } from "./protected-tail-boundary";
@@ -203,7 +205,7 @@ export async function runCompartmentAgent(deps: CompartmentRunnerDeps): Promise<
                 ? priorCompartments[priorCompartments.length - 1].endMessage + 1
                 : 1;
 
-        const boundarySnapshot =
+        let boundarySnapshot =
             deps.boundarySnapshot ??
             (process.env.NODE_ENV === "test"
                 ? createDefaultBoundarySnapshotForTests(sessionId)
@@ -217,7 +219,7 @@ export async function runCompartmentAgent(deps: CompartmentRunnerDeps): Promise<
             rollbackDrainReservation();
             return;
         }
-        const validation =
+        let validation =
             boundarySnapshot.rawRangeFingerprint.length > 0
                 ? validateBoundarySnapshot({
                       db,
@@ -226,6 +228,42 @@ export async function runCompartmentAgent(deps: CompartmentRunnerDeps): Promise<
                           deps.currentContextLimit ?? boundarySnapshot.contextLimit,
                   })
                 : { ok: true };
+        // In an active session the protected tail's newest message changes every
+        // turn (a fresh user/assistant message lands), so a snapshot captured at
+        // trigger time goes stale on the "last ordinal id" check by the time the
+        // historian actually runs — even though the ELIGIBLE HEAD (offset →
+        // eligibleEnd) it would compact is untouched. Left as-is the runner no-ops
+        // forever while the trigger refires each turn, and queued drop ops starve
+        // (observed in production: 27 consecutive stale-snapshot no-ops, 179
+        // pending drops, zero reduction). Re-resolve the boundary ONCE from the
+        // CURRENT session state and adopt the fresh snapshot when it still exposes
+        // a runnable head. This does NOT weaken the protected-tail guarantee: the
+        // refreshed snapshot recomputes protectedTailStart/eligibleEnd from the
+        // live messages, so the head can never include a message that now belongs
+        // to the current protected tail.
+        if (!validation.ok && validation.reason === "stale_snapshot") {
+            const refreshed = resolveOpenCodeProtectedTailBoundary({
+                db,
+                sessionId,
+                mode: "incremental-runner",
+                contextLimit: deps.currentContextLimit ?? boundarySnapshot.contextLimit,
+                executeThresholdPercentage: boundarySnapshot.executeThresholdPercentage,
+                usage: {
+                    percentage: boundarySnapshot.usagePercentage,
+                    inputTokens: boundarySnapshot.usageInputTokens,
+                },
+                usageSource: boundarySnapshot.usageSource,
+                emergencyTailScale: boundarySnapshot.emergencyTailScale,
+            });
+            if (hasRunnableCompartmentWindow(refreshed)) {
+                sessionLog(
+                    sessionId,
+                    `historian: refreshed stale protected-tail snapshot at run time (was: ${validation.detail ?? "stale"}) — eligible head ${refreshed.offset}-${refreshed.eligibleEndOrdinal - 1}`,
+                );
+                boundarySnapshot = refreshed;
+                validation = { ok: true };
+            }
+        }
         if (!validation.ok) {
             sessionLog(
                 sessionId,
@@ -334,6 +372,14 @@ export async function runCompartmentAgent(deps: CompartmentRunnerDeps): Promise<
             rollbackDrainReservation();
             return;
         }
+
+        // Past every synchronous no-op early-return and immediately before the
+        // first `await` (client.session.get below): we are now committed to a
+        // real historian pass. Signal the caller so startCompartmentAgent keeps
+        // the active-run registration; a synchronous no-op above never reaches
+        // here, so its lingering registration is cleared instead of blocking the
+        // same transform pass's pending-op drain.
+        deps.onHistorianRunStarted?.();
 
         // v2 bounded reference model (replaces the unbounded existing_state dump):
         //   - 4 rotating cross-project seeds + last-6 recency compartments (no

--- a/packages/plugin/src/hooks/magic-context/compartment-runner-types.ts
+++ b/packages/plugin/src/hooks/magic-context/compartment-runner-types.ts
@@ -117,6 +117,16 @@ export interface CompartmentRunnerDeps {
     onDeferredMarkerPending?: (sessionId: string) => void;
     /** Holder id for the DB-backed compartment-state lease guarding publish paths. */
     compartmentLeaseHolderId?: string;
+    /**
+     * Called synchronously the moment the runner commits to a REAL historian
+     * pass — after every no-op early-return (stale/empty snapshot, nothing to
+     * compact, drain-quota) and immediately before the first `await`. Lets
+     * `startCompartmentAgent` distinguish a fire-and-forget run that actually
+     * started from one that no-op'd synchronously, so a no-op does not leave
+     * the rest of the transform pass believing a historian is in progress
+     * (which would defer queued drop ops — the production livelock).
+     */
+    onHistorianRunStarted?: () => void;
 }
 
 export interface CandidateCompartment {

--- a/packages/plugin/src/hooks/magic-context/compartment-runner.test.ts
+++ b/packages/plugin/src/hooks/magic-context/compartment-runner.test.ts
@@ -36,6 +36,10 @@ import {
     runCompartmentAgent,
     startCompartmentAgent,
 } from "./compartment-runner";
+import {
+    hasRunnableCompartmentWindow,
+    resolveOpenCodeProtectedTailBoundary,
+} from "./protected-tail-boundary";
 import { tagMessages } from "./tag-messages";
 
 const tempDirs: string[] = [];
@@ -1780,6 +1784,186 @@ describe("runCompartmentAgent", () => {
         expect(notice).toContain("magic-context.jsonc");
         // The escalated notice surfaces the real error for diagnosis.
         expect(notice).toContain("historian model unavailable");
+    });
+
+    // Regression: production livelock (ses_157f877e2ffepme9doYf3RTnRx). In an
+    // active session the protected tail's newest message changes every turn, so
+    // the trigger-time boundary snapshot fails validation on the "last ordinal
+    // id changed" check by the time the historian runs — even though the eligible
+    // HEAD it would compact is untouched. The runner used to no-op forever while
+    // the trigger refired each turn and queued drop ops starved. It must now
+    // re-resolve the boundary at run time and make real progress.
+    it("refreshes a stale-tail boundary snapshot at run time instead of no-op'ing forever", async () => {
+        useTempDataHome("compartment-runner-stale-tail-refresh-");
+        createOpenCodeDb("ses-stale-tail", [
+            { id: "m-1", role: "user", text: `eligible head one ${"detail ".repeat(150)}` },
+            { id: "m-2", role: "assistant", text: `eligible head two ${"detail ".repeat(150)}` },
+            { id: "m-3", role: "user", text: `tail ${"context ".repeat(3000)}` },
+        ]);
+        const db = openDatabase();
+
+        // Tag the eligible head so a successful publish also queues drop ops —
+        // proving the stale→refresh→publish chain that feeds drop application.
+        tagMessages(
+            "ses-stale-tail",
+            [
+                {
+                    info: { id: "m-1", role: "user", sessionID: "ses-stale-tail" },
+                    parts: [{ type: "text", text: `eligible head one ${"detail ".repeat(150)}` }],
+                },
+                {
+                    info: { id: "m-2", role: "assistant", sessionID: "ses-stale-tail" },
+                    parts: [{ type: "text", text: `eligible head two ${"detail ".repeat(150)}` }],
+                },
+            ],
+            createTagger(),
+            db,
+        );
+
+        // Resolve a genuine snapshot (correct fingerprint + ids), then corrupt
+        // ONLY the recorded last-tail id to simulate the live tail advancing
+        // between trigger and run. Every other check (offset, protectedTailStart,
+        // eligibleEnd, eligible-range fingerprint) still passes — exactly the
+        // production failure mode.
+        const realSnapshot = resolveOpenCodeProtectedTailBoundary({
+            db,
+            sessionId: "ses-stale-tail",
+            mode: "trigger",
+            contextLimit: 8_000,
+            executeThresholdPercentage: 65,
+            usage: { percentage: 95, inputTokens: 7_600 },
+            usageSource: "live",
+        });
+        expect(hasRunnableCompartmentWindow(realSnapshot)).toBe(true);
+        expect(realSnapshot.offset).toBe(1);
+        expect(realSnapshot.eligibleEndOrdinal).toBeGreaterThan(realSnapshot.offset);
+        expect(realSnapshot.rawRangeFingerprint.length).toBeGreaterThan(0);
+        const staleSnapshot = {
+            ...realSnapshot,
+            rawLastMessageIdAtTrigger: "m-vanished-live-tail",
+        };
+
+        const client = {
+            session: {
+                get: mock(async () => ({ data: { directory: "/tmp/stale-tail" } })),
+                create: mock(async () => ({ data: { id: "ses-agent-stale-tail" } })),
+                prompt: mock(async () => ({})),
+                messages: mock(async () => ({
+                    data: [
+                        {
+                            info: { role: "assistant", time: { created: 1 } },
+                            parts: [
+                                {
+                                    type: "text",
+                                    text: '<compartment start="1" end="2" title="Eligible head">Head summary</compartment>',
+                                },
+                            ],
+                        },
+                    ],
+                })),
+                delete: mock(async () => ({})),
+            },
+        } as unknown as PluginContext["client"];
+
+        await runCompartmentAgentWithLease({
+            client,
+            db,
+            sessionId: "ses-stale-tail",
+            historianChunkTokens: 10_000,
+            directory: "/tmp",
+            boundarySnapshot: staleSnapshot,
+            currentContextLimit: 8_000,
+        });
+
+        // Re-derived and PUBLISHED rather than no-op'ing: progress is made.
+        const compartments = getCompartments(db, "ses-stale-tail");
+        expect(compartments).toHaveLength(1);
+        expect(compartments[0]?.startMessage).toBe(1);
+        expect(compartments[0]?.endMessage).toBe(2);
+        // And the published compartment queued drops for its covered tags, so the
+        // accumulated pending ops can finally drain (no starvation).
+        expect(getPendingOps(db, "ses-stale-tail").length).toBeGreaterThan(0);
+        expect(getOrCreateSessionMeta(db, "ses-stale-tail").compartmentInProgress).toBe(false);
+    });
+
+    // Regression: a synchronous runner no-op (stale/empty snapshot, nothing to
+    // compact) must NOT leave the rest of the transform pass believing a historian
+    // is in progress. startCompartmentAgent registers the run in `activeRuns`
+    // BEFORE the (microtask-scheduled) promise.finally can clear it; postprocess
+    // reads `getActiveCompartmentRun` synchronously in the same pass and would
+    // defer queued drop ops for a run that already finished. The no-op must clear
+    // the registration synchronously.
+    it("clears the active-run registration synchronously when the runner no-ops", async () => {
+        useTempDataHome("compartment-runner-sync-noop-clear-");
+        createOpenCodeDb("ses-sync-noop", [
+            { id: "m-1", role: "user", text: "only protected 1" },
+            { id: "m-2", role: "user", text: "only protected 2" },
+            { id: "m-3", role: "user", text: "only protected 3" },
+        ]);
+        const db = openDatabase();
+
+        // protectedTailStart === offset (1) → "nothing to compact" no-op, which
+        // returns synchronously before any await. Empty fingerprint skips the
+        // validation branch so we land squarely on the nothing-to-compact path.
+        const noopSnapshot = {
+            sessionId: "ses-sync-noop",
+            mode: "trigger" as const,
+            offset: 1,
+            offsetMessageId: "m-1",
+            protectedTailStart: 1,
+            protectedTailStartMessageId: "m-1",
+            eligibleEndOrdinal: 1,
+            eligibleEndMessageId: null,
+            rawMessageCountAtTrigger: 3,
+            rawLastMessageIdAtTrigger: "m-3",
+            N: 1_000,
+            usagePercentage: 10,
+            usageInputTokens: 1_000,
+            usageSource: "live" as const,
+            contextLimit: 128_000,
+            executeThresholdPercentage: 65,
+            triggerBudget: 5_000,
+            priorBoundaryOrdinal: 1,
+            migrationFloorActive: false,
+            providerShapeVersion: "opencode-v1" as const,
+            cacheNamespace: "test:ses-sync-noop",
+            createdAt: Date.now(),
+            rawRangeFingerprint: "",
+            trueRawEligibleTokens: 0,
+            oversizeAtomicUnit: false,
+            boundaryReason: "size-walk",
+        };
+
+        const client = {
+            session: {
+                get: mock(async () => ({ data: { directory: "/tmp/sync-noop" } })),
+                create: mock(async () => ({ data: { id: "ses-agent-sync-noop" } })),
+                prompt: mock(async () => ({})),
+                messages: mock(async () => ({ data: [] })),
+                delete: mock(async () => ({})),
+            },
+        } as unknown as PluginContext["client"];
+
+        startCompartmentAgent({
+            client,
+            db,
+            sessionId: "ses-sync-noop",
+            historianChunkTokens: 10_000,
+            directory: "/tmp",
+            boundarySnapshot: noopSnapshot,
+            currentContextLimit: 128_000,
+        });
+
+        // SYNCHRONOUS assertion (no await): the no-op already cleared the
+        // registration, so the same transform pass sees no active run and can
+        // materialize queued drops instead of deferring them forever.
+        expect(getActiveCompartmentRun("ses-sync-noop")).toBeUndefined();
+        expect(getOrCreateSessionMeta(db, "ses-sync-noop").compartmentInProgress).toBe(false);
+
+        // Let the fire-and-forget promise settle so its finally clears the lease
+        // renewal interval before the db closes.
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        expect(getActiveCompartmentRun("ses-sync-noop")).toBeUndefined();
     });
 });
 

--- a/packages/plugin/src/hooks/magic-context/compartment-runner.ts
+++ b/packages/plugin/src/hooks/magic-context/compartment-runner.ts
@@ -124,7 +124,14 @@ export function startCompartmentAgent(deps: CompartmentRunnerDeps): void {
     // Track the real underlying promise — NOT a raced wrapper.
     // This ensures activeRuns.has(sessionId) stays true until the historian run
     // actually completes, preventing duplicate runs even if an external await times out.
-    const runnerDeps = withPublishedCallback({ ...deps, compartmentLeaseHolderId: holderId });
+    let realRunStarted = false;
+    const runnerDeps = withPublishedCallback({
+        ...deps,
+        compartmentLeaseHolderId: holderId,
+        onHistorianRunStarted: () => {
+            realRunStarted = true;
+        },
+    });
     const promise = runCompartmentAgent(runnerDeps)
         .catch((err) => {
             sessionLog(deps.sessionId, "compartment agent: unhandled rejection:", err);
@@ -143,6 +150,20 @@ export function startCompartmentAgent(deps: CompartmentRunnerDeps): void {
             }
         });
     activeRuns.set(deps.sessionId, { promise, published: false });
+    // If the runner no-op'd synchronously (stale/empty snapshot, nothing to
+    // compact, drain-quota), it returned before signalling onHistorianRunStarted
+    // and before any `await`, so `promise` is already settling. It cleared
+    // compartmentInProgress in its own finally, but the activeRuns entry above
+    // would otherwise survive (cleared only by the microtask-scheduled
+    // promise.finally) and make the SAME transform pass treat a non-running
+    // historian as in-progress — deferring queued drop ops and starving them
+    // turn after turn (the production livelock). Drop the registration
+    // synchronously so pending ops can materialize this pass. The promise.finally
+    // below still runs for interval/lease cleanup; its `=== promise` guard makes
+    // the (now redundant) delete a no-op.
+    if (!realRunStarted && activeRuns.get(deps.sessionId)?.promise === promise) {
+        activeRuns.delete(deps.sessionId);
+    }
 }
 
 export interface ExecuteContextRecompOptions {


### PR DESCRIPTION
## Problem

In an active session, the historian can livelock and pending drop operations starve forever. Observed in production (OpenCode harness): a session accumulated 179 pending drops while active context grew past 280K tokens with zero reduction.

The cycle, repeating every turn:

1. commit-cluster trigger fires (clusters never get compartmentalized, so it refires every turn)
2. `compartmentInProgress` flag set, historian agent starts
3. `historian no-op: stale protected-tail snapshot (last ordinal N id changed)` — the boundary snapshot is captured at trigger time, and the ONLY failing validation is the "last message in protected tail" tuple, which changes every turn in an active session
4. `transform: deferring pending ops — compartment agent in progress` — the no-op returns synchronously, but the `activeRuns` registration is only cleared via a microtask `promise.finally`, so the same pass still believes a run is active and defers pending ops

## Fix (two independent defects)

1. **Re-derive the boundary snapshot at run time on staleness.** On a `stale_snapshot` validation result, the runner re-resolves the boundary once from current session state and adopts it if it still has a runnable head. `validateBoundarySnapshot` itself is untouched — the refreshed snapshot recomputes `protectedTailStart`/`eligibleEnd` from live messages, so the compacted head can never include a message that belongs to the live protected tail.
2. **Synchronous no-op clears the active-run registration.** `startCompartmentAgent` now registers the run at the real-run commit point (after the last synchronous no-op return, before the first await) via `onHistorianRunStarted`, and drops the registration synchronously when the runner no-ops — so pending ops can materialize in the same pass.

## Tests

Two regression tests in `compartment-runner.test.ts`:
- refreshes a stale-tail boundary snapshot at run time instead of no-op'ing forever (asserts publish + queued drops + `compartmentInProgress=false`)
- clears the active-run registration synchronously when the runner no-ops

`bun run typecheck`, `bun run lint`, full plugin suite pass (the two pre-existing flaky timing tests aside).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/magic-context/pr/141"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783885617&installation_id=135454708&pr_number=141&repository=cortexkit%2Fmagic-context&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Fmagic-context%2Fpull%2F141&signature=98e6f399c00dc661a9104c3c2c65db1234103345b33f8f20757f20133a6c22d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a historian livelock that starved pending drop ops in active sessions. The runner now refreshes stale boundaries and clears no-op runs immediately, so compaction proceeds and drops drain.

- **Bug Fixes**
  - Re-resolves the protected-tail boundary on `stale_snapshot` at run time and adopts it only if the head is runnable, preserving protected-tail safety.
  - Clears active-run registration synchronously on no-op via `onHistorianRunStarted`, so `activeRuns` doesn’t block pending drops in the same pass.

<sup>Written for commit 055da42fb6822c0ad0f953f599d1500c3e5a7814. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/magic-context/pull/141?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a production livelock where the historian agent repeatedly no-ops due to a stale boundary snapshot while pending drop operations starve indefinitely. Two independent defects are addressed: (1) on a `stale_snapshot` validation result the runner now re-resolves the boundary once from live DB state and proceeds if a runnable window still exists, and (2) the `activeRuns` registration is cleared synchronously when the runner determines it will no-op, so the same transform pass can drain pending drops instead of deferring them.

- **Stale-snapshot refresh** (`compartment-runner-incremental.ts`): when `validateBoundarySnapshot` returns `reason: \"stale_snapshot\"`, the runner calls `resolveOpenCodeProtectedTailBoundary` against the live DB and adopts the refreshed snapshot if `hasRunnableCompartmentWindow` is satisfied. The runner's own `eligibleEndOrdinal = Math.min(snapshot.eligibleEndOrdinal, protectedTailStart)` clamp maintains the protected-tail guarantee regardless of snapshot staleness.
- **Synchronous `activeRuns` cleanup** (`compartment-runner.ts`): `startCompartmentAgent` introduces a `realRunStarted` boolean set by the new `onHistorianRunStarted` callback, called just before the first real `await`. After `runCompartmentAgent` is launched, if `realRunStarted` is still false the registration is deleted synchronously before the microtask-scheduled `.finally` can clear it — unblocking pending-op drain in the same pass.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge — the two independent fixes address a well-documented production livelock with targeted, narrow changes backed by regression tests.

Both changes are tightly scoped and the core safety guarantee (protected tail never compacted) is enforced by the runner's own Math.min(eligibleEndOrdinal, protectedTailStart) clamp independent of the refreshed snapshot. The realRunStarted mechanism is correct for both synchronous and async no-op paths. The two findings are documentation and clarity gaps, not behavioral defects.

The stale-snapshot refresh block in compartment-runner-incremental.ts (lines 244–266) and the matching onHistorianRunStarted comment in both compartment-runner-incremental.ts and compartment-runner.ts would benefit from a one-line clarification about async early-return coverage and stale usage forwarding.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/plugin/src/hooks/magic-context/compartment-runner.ts | Introduces realRunStarted flag + onHistorianRunStarted callback to synchronously clear activeRuns when the runner no-ops; lease and interval cleanup still run via .finally() microtask. Logic is sound for both synchronous and async no-op paths. |
| packages/plugin/src/hooks/magic-context/compartment-runner-incremental.ts | Adds stale-snapshot refresh: on stale_snapshot validation failure, re-resolves boundary from live DB using trigger-time usage/threshold params and adopts it when hasRunnableCompartmentWindow passes. Protected-tail safety is preserved by the runner's own Math.min(eligibleEndOrdinal, protectedTailStart) clamp downstream. |
| packages/plugin/src/hooks/magic-context/compartment-runner-types.ts | Adds optional onHistorianRunStarted callback to CompartmentRunnerDeps with clear JSDoc; no breaking changes. |
| packages/plugin/src/hooks/magic-context/compartment-runner.test.ts | Adds two targeted regression tests: stale-tail refresh (verifies publish + pending ops + compartmentInProgress=false) and sync-noop activeRuns cleanup (synchronous assertion before any await). Both cover the exact production failure modes described in the PR. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant T as Transform Pass
    participant SCA as startCompartmentAgent
    participant RCA as runCompartmentAgent
    participant DB as DB / State

    T->>SCA: startCompartmentAgent(deps)
    SCA->>DB: acquireCompartmentLease()
    SCA->>RCA: runCompartmentAgent(runnerDeps) [fire-and-forget]

    alt No-op path (stale snapshot)
        RCA->>DB: validateBoundarySnapshot → stale_snapshot
        Note over RCA: NEW: re-resolve boundary
        RCA->>DB: resolveOpenCodeProtectedTailBoundary (live)
        alt hasRunnableCompartmentWindow
            RCA->>RCA: "boundarySnapshot = refreshed, validation.ok = true"
            Note over RCA: continues to real run
            RCA-->>SCA: onHistorianRunStarted() called
            Note over SCA: realRunStarted = true
            RCA->>DB: publish compartments
        else no runnable window
            RCA-->>RCA: rollback, return (no await reached)
            Note over SCA: realRunStarted = false
        end
    else No-op path (nothing to compact)
        RCA-->>RCA: rollback, return synchronously
        Note over SCA: realRunStarted = false
    end

    SCA->>SCA: activeRuns.set(sessionId, promise)
    Note over SCA: NEW: if (!realRunStarted) activeRuns.delete() synchronously
    SCA-->>T: returns

    T->>T: getActiveCompartmentRun() → undefined
    T->>DB: drain pending drops (no longer blocked)

    Note over RCA: microtask later: .finally() clears interval + lease
```
</details>

<sub>Reviews (1): Last reviewed commit: ["plugin: refresh protected-tail snapshot ..."](https://github.com/cortexkit/magic-context/commit/055da42fb6822c0ad0f953f599d1500c3e5a7814) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37303454)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->