### PR TITLE
fix: restore message snapshot when tagging fails mid-pass

### DIFF
--- a/packages/plugin/src/hooks/magic-context/transform.test.ts
+++ b/packages/plugin/src/hooks/magic-context/transform.test.ts
@@ -23,6 +23,7 @@ import {
     getLastNudgeUndropped,
     getOrCreateSessionMeta,
     getPendingOps,
+    getSourceContents,
     getTagById,
     getTagsBySession,
     incrementHistorianFailure,
@@ -205,6 +206,142 @@ describe("createTransform", () => {
         expect(text(messages[0], 0)).toStartWith("§1§ ");
         expect(text(messages[1], 0)).toContain("§2§ ");
         expect(toolOutput(messages[1], 1)).toStartWith("§3§ ");
+    });
+
+    it("restores message content when tagging throws mid-pass (no partial §N§ prefixes)", async () => {
+        //#given
+        useTempDataHome("context-transform-tag-rollback-");
+        const scheduler: Scheduler = { shouldExecute: mock(() => "defer" as const) };
+        const db = openDatabase();
+        // Real tagger whose assignTag throws on the SECOND call: the first text
+        // part is tagged + §1§-prefixed in place, then the second throws, so the
+        // pass aborts with message[0] already carrying a partial prefix.
+        const realTagger = createTagger();
+        let assignCalls = 0;
+        const tagger: ReturnType<typeof createTagger> = {
+            ...realTagger,
+            assignTag(...args: Parameters<typeof realTagger.assignTag>) {
+                assignCalls += 1;
+                if (assignCalls >= 2) {
+                    throw new Error("forced tag failure after first assign");
+                }
+                return realTagger.assignTag(...args);
+            },
+        };
+        const transform = createTransform({
+            tagger,
+            scheduler,
+            contextUsageMap: new Map<string, { usage: ContextUsage; updatedAt: number }>([
+                [
+                    "ses-rollback",
+                    { usage: { percentage: 46, inputTokens: 92_000 }, updatedAt: Date.now() },
+                ],
+            ]),
+            db,
+            historyRefreshSessions: new Set<string>(),
+            pendingMaterializationSessions: new Set<string>(),
+            lastHeuristicsTurnId: new Map<string, string>(),
+            clearReasoningAge: 50,
+            protectedTags: 0,
+        });
+        const messages: TestMessage[] = [
+            {
+                info: { id: "m-user", role: "user", sessionID: "ses-rollback" },
+                parts: [{ type: "text", text: "Plan this change" }],
+            },
+            {
+                info: { id: "m-assistant", role: "assistant" },
+                parts: [{ type: "text", text: "Implemented the change" }],
+            },
+        ];
+
+        //#when — tagging throws after the first part was already prefixed.
+        await transform({}, { messages });
+
+        //#then — the in-memory rollback leaves NO partial §N§ prefixes behind.
+        expect(assignCalls).toBeGreaterThanOrEqual(2);
+        for (const message of messages) {
+            for (const part of message.parts) {
+                if (part.type === "text") {
+                    expect(part.text).not.toMatch(/§\d+§/);
+                }
+            }
+        }
+        expect(text(messages[0], 0)).toBe("Plan this change");
+        expect(text(messages[1], 0)).toBe("Implemented the change");
+    });
+
+    it("keeps persisting source_contents and replaying drops on the happy path", async () => {
+        //#given
+        useTempDataHome("context-transform-snapshot-happy-");
+        const scheduler: Scheduler = { shouldExecute: mock(() => "defer" as const) };
+        const db = openDatabase();
+        const tagger = createTagger();
+        const makeTransform = () =>
+            createTransform({
+                tagger,
+                scheduler,
+                contextUsageMap: new Map<string, { usage: ContextUsage; updatedAt: number }>([
+                    [
+                        "ses-snapshot-happy",
+                        { usage: { percentage: 30, inputTokens: 60_000 }, updatedAt: Date.now() },
+                    ],
+                ]),
+                db,
+                historyRefreshSessions: new Set<string>(),
+                pendingMaterializationSessions: new Set<string>(),
+                lastHeuristicsTurnId: new Map<string, string>(),
+                clearReasoningAge: 50,
+                protectedTags: 0,
+            });
+        const firstPass: TestMessage[] = [
+            {
+                info: { id: "m-user", role: "user", sessionID: "ses-snapshot-happy" },
+                parts: [{ type: "text", text: "Plan this change carefully" }],
+            },
+            {
+                info: { id: "m-assistant", role: "assistant" },
+                parts: [{ type: "text", text: "Implemented the whole thing in detail" }],
+            },
+        ];
+
+        //#when — first (successful) pass tags both messages.
+        await makeTransform()({}, { messages: firstPass });
+
+        //#then — source_contents persisted the PRE-PREFIX original text per tag.
+        const tags = getTagsBySession(db, "ses-snapshot-happy");
+        const userTag = tags.find((tag) => tag.messageId === "m-user:p0");
+        const assistantTag = tags.find((tag) => tag.messageId === "m-assistant:p0");
+        expect(userTag).toBeDefined();
+        expect(assistantTag).toBeDefined();
+        const sources = getSourceContents(db, "ses-snapshot-happy", [
+            userTag!.tagNumber,
+            assistantTag!.tagNumber,
+        ]);
+        expect(sources.get(userTag!.tagNumber)).toBe("Plan this change carefully");
+        expect(sources.get(assistantTag!.tagNumber)).toBe("Implemented the whole thing in detail");
+
+        //#given — the assistant tag is dropped out of band.
+        updateTagStatus(db, "ses-snapshot-happy", assistantTag!.tagNumber, "dropped");
+
+        //#when — a second successful pass replays the dropped status.
+        const secondPass: TestMessage[] = [
+            {
+                info: { id: "m-user", role: "user", sessionID: "ses-snapshot-happy" },
+                parts: [{ type: "text", text: "Plan this change carefully" }],
+            },
+            {
+                info: { id: "m-assistant", role: "assistant" },
+                parts: [{ type: "text", text: "Implemented the whole thing in detail" }],
+            },
+        ];
+        await makeTransform()({}, { messages: secondPass });
+
+        //#then — active user tag keeps prefixed content; dropped assistant tag is
+        // replayed to the [dropped §N§] sentinel (snapshot/restore is a no-op here).
+        expect(text(secondPass[0], 0)).toStartWith("§");
+        expect(text(secondPass[0], 0)).toContain("Plan this change carefully");
+        expect(text(secondPass[1], 0)).toBe(`[dropped §${assistantTag!.tagNumber}§]`);
     });
 
     it("does not inject user messages for emergency nudges (handled by promptAsync)", async () => {

--- a/packages/plugin/src/hooks/magic-context/transform.ts
+++ b/packages/plugin/src/hooks/magic-context/transform.ts
@@ -158,6 +158,26 @@ function findLastAssistantModel(
     return null;
 }
 
+/**
+ * Deep-clone the visible message window before tagMessages() mutates it.
+ *
+ * tagMessages walks the array and rewrites part text in place (assignTag →
+ * prependTag injects §N§ prefixes, and persisted source restores rewrite
+ * textPart.text). It intentionally runs WITHOUT an outer DB transaction (see
+ * tag-messages.ts) so a mid-walk throw can leave earlier messages carrying
+ * partial §N§ prefixes while the DB has no record of them — silently
+ * corrupting the prompt sent to the LLM. We snapshot {info, parts} so the
+ * catch path can roll the in-memory array back to its pre-tag state.
+ *
+ * Parts are JSON-like OpenCode payloads, so structuredClone is sufficient.
+ */
+function snapshotMessagesForTagging(messages: MessageLike[]): MessageLike[] {
+    return messages.map((message) => ({
+        info: structuredClone(message.info),
+        parts: structuredClone(message.parts),
+    }));
+}
+
 export interface TransformDeps {
     tagger: Tagger;
     scheduler: Scheduler;
@@ -1102,6 +1122,10 @@ export function createTransform(deps: TransformDeps) {
             logTransformTiming(sessionId, "injectTemporalMarkers", tTemporal);
         }
 
+        // Snapshot the pre-tag message window so a mid-walk tagging failure can be
+        // rolled back. tagMessages mutates parts in place and has no outer
+        // transaction, so without this a partial pass leaves stray §N§ prefixes.
+        const preTagSnapshot = snapshotMessagesForTagging(messages);
         let taggingSucceeded = false;
         try {
             const t0 = performance.now();
@@ -1145,6 +1169,13 @@ export function createTransform(deps: TransformDeps) {
                 "transform tag persistence failed; continuing without tagging:",
                 error,
             );
+            // Roll back the in-memory mutations applied before the throw.
+            // tagMessages prefixes/rewrites part text in place, so a mid-walk
+            // failure can leave earlier messages with partial §N§ prefixes.
+            // Restore the ARRAY CONTENTS (not a local rebind) so the emitted
+            // prompt matches the pre-tag state; taggingSucceeded stays false so
+            // the downstream mutation stages remain gated.
+            messages.splice(0, messages.length, ...preTagSnapshot);
             // Drop in-memory tagger state for this session so the next pass
             // re-loads from the DB. Without this, a stale counter or stale
             // assignments map can keep producing the same UNIQUE collision


### PR DESCRIPTION
## Problem

`tagMessages()` mutates message parts in place (e.g. `§N§` text prefixing) after each DB write. If it throws mid-pass (DB error, etc.), the emitted `messages` array keeps the partial mutations — the LLM silently receives a prompt with partial tag prefixes that don't correspond to persisted state.

## Fix

Snapshot `{ info, parts }` (structuredClone) immediately before `tagMessages()`; on the tagging-failure catch path, restore via `messages.splice(0, messages.length, ...snapshot)`. The existing `taggingSucceeded` gate and the documented no-outer-transaction design of `tagMessages()` are untouched — this only rolls back in-memory mutations, not durable DB semantics.

## Tests

- mid-pass failure: tagger throws on the 2nd message after the 1st was already prefixed → asserts no part contains a `§N§` prefix and both messages match their pre-tag text
- happy path: successful pass still persists `source_contents` and replays dropped statuses (snapshot/restore is a no-op on success)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/magic-context/pr/142"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783885629&installation_id=135454708&pr_number=142&repository=cortexkit%2Fmagic-context&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Fmagic-context%2Fpull%2F142&signature=d9e278c9d4fdc39ee485bf3af2f89a5561636047869c15d5101e15b2ec25baf3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR guards against partial in-memory corruption when `tagMessages()` throws mid-walk by taking a `structuredClone` snapshot of `{info, parts}` immediately before the call and splicing the snapshot back on the catch path. The existing `taggingSucceeded` gate and no-outer-transaction design of `tagMessages` are left intact.

- `snapshotMessagesForTagging` clones every message's `info` and `parts` before tagging begins; on failure the `messages` array contents are restored so no stray `§N§` prefixes reach the LLM.
- Two new integration tests cover the rollback path (tagger forced to throw on the 2nd `assignTag`, asserts all text reverts to pre-tag content) and the happy path (source_contents and dropped-status replay still work correctly after the snapshot code was added).
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge; the fix correctly restores the message array on the failure path and is well-tested, with two minor robustness items worth a follow-up.

The snapshot/restore logic is sound and the taggingSucceeded gate prevents downstream stages from running on stale data. Two items are worth noting: structuredClone is called outside the try-catch so a DataCloneError from a non-cloneable part would bubble up as an unhandled transform failure, and the ...preTagSnapshot spread into splice has a theoretical argument-count ceiling. Neither is likely to trigger in practice given JSON-like parts and bounded message windows.

packages/plugin/src/hooks/magic-context/transform.ts — specifically the placement of snapshotMessagesForTagging relative to the try-catch and the splice restore pattern.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/plugin/src/hooks/magic-context/transform.ts | Adds snapshotMessagesForTagging helper and a messages.splice restore on the tagging catch path; snapshot is taken outside the try-catch (structuredClone failure would be unhandled) and the spread-into-splice pattern has a theoretical argument-count ceiling. |
| packages/plugin/src/hooks/magic-context/transform.test.ts | Adds two new integration tests: mid-pass rollback (tagger throws on 2nd assignTag, asserts no §N§ prefixes survive) and happy-path regression (source_contents persisted, dropped status replayed correctly after snapshot code was added). |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant T as transform()
    participant S as snapshotMessagesForTagging()
    participant TM as tagMessages()
    participant DB as ContextDatabase

    T->>S: "structuredClone({info, parts}) for each message"
    S-->>T: preTagSnapshot[]

    T->>TM: tagMessages(sessionId, messages, tagger, db)
    loop per message part
        TM->>DB: tagger.assignTag() SAVEPOINT
        DB-->>TM: tag number
        TM->>TM: prependTag mutates part.text in place
    end

    alt tagging succeeds
        TM-->>T: TagMessagesResult
        T->>T: "taggingSucceeded = true"
        Note over T: downstream stages run normally
    else tagMessages throws mid-walk
        TM--xT: Error
        Note over T: messages[0] already has §1§ prefix
        T->>T: restore via splice
        Note over T: in-memory array restored to pre-tag state
        T->>T: tagger.cleanup(sessionId)
        Note over T: taggingSucceeded stays false
    end
```
</details>

<sub>Reviews (1): Last reviewed commit: ["plugin: restore message snapshot when ta..."](https://github.com/cortexkit/magic-context/commit/ef0f13b554e0cd6b6ef2ff854f13f57c5ed77c8c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37303487)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the pre-tag message snapshot when `tagMessages()` fails mid-pass, preventing partial `§N§` prefixes from leaking into prompts. Keeps LLM input consistent with persisted state.

- **Bug Fixes**
  - Take a deep snapshot of `{ info, parts }` before tagging and splice it back on failure.
  - Keep `taggingSucceeded` gating and DB semantics unchanged; only in-memory mutations are rolled back.
  - Add integration tests for mid-pass rollback and the happy path (persisting `source_contents` and replaying dropped status).

<sup>Written for commit ef0f13b554e0cd6b6ef2ff854f13f57c5ed77c8c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/magic-context/pull/142?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

