### PR TITLE
fix(plugin): stop exporting buildHiddenAgentConfig — opencode 1.17 invokes every entry export as a plugin factory

### DIFF
--- a/packages/plugin/src/hidden-agent-config.ts
+++ b/packages/plugin/src/hidden-agent-config.ts
@@ -1,0 +1,51 @@
+import { buildAllowOnlyPermission } from "./agents/permissions";
+
+/**
+ * Build a hidden-agent config with a deny-everything-by-default permission
+ * baseline and a hard tool-iteration ceiling. User overrides may lower
+ * `steps`/`maxSteps`, but cannot raise either above the built-in cap.
+ *
+ * Lives in its own module — NOT in the plugin entry (`index.ts`) — because
+ * opencode 1.17 invokes EVERY exported function in a plugin's entry module as
+ * its own plugin factory. Exporting this helper from `index.ts` made opencode
+ * call it as `buildHiddenAgentConfig(ctx)`, passing the plugin context as
+ * `prompt` and `undefined` as `allowedTools`, which crashed plugin load
+ * ("undefined is not an object (evaluating 'allowedTools')"). The entry module
+ * must export only `default`; helpers that need to be exported (e.g. for tests)
+ * live in sibling modules like this one.
+ */
+export function buildHiddenAgentConfig(
+    prompt: string,
+    allowedTools: readonly string[],
+    maxSteps: number,
+    overrides?: Record<string, unknown>,
+) {
+    const { permission: overridePermission, ...restOverrides } = (overrides ?? {}) as {
+        permission?: Record<string, unknown>;
+        [key: string]: unknown;
+    };
+    const basePermission = buildAllowOnlyPermission(allowedTools);
+    return {
+        prompt,
+        // No builtin fallback chain: the user's `fallback_models` (if any) flow
+        // through `restOverrides`. A hardcoded chain names providers the user may
+        // not have, producing `Model not found` retry storms.
+        ...restOverrides,
+        steps: clampHiddenAgentStepLimit(restOverrides.steps, maxSteps),
+        maxSteps: clampHiddenAgentStepLimit(restOverrides.maxSteps, maxSteps),
+        // Permission baseline goes after `restOverrides` so that accidental
+        // `permission` keys in user overrides we DIDN'T explicitly destructure
+        // can't bypass the deny. The explicit override (destructured above) is
+        // then layered on top.
+        permission: {
+            ...basePermission,
+            ...(overridePermission ?? {}),
+        },
+        mode: "subagent" as const,
+        hidden: true,
+    };
+}
+
+function clampHiddenAgentStepLimit(value: unknown, cap: number): number {
+    return typeof value === "number" && Number.isFinite(value) ? Math.min(value, cap) : cap;
+}

--- a/packages/plugin/src/index-refresh.test.ts
+++ b/packages/plugin/src/index-refresh.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { buildHiddenAgentConfig } from "./index";
+import { buildHiddenAgentConfig } from "./hidden-agent-config";
 
 describe("plugin model-limit cache warmup", () => {
     test("warms model limits once at startup and does not schedule periodic refresh", () => {

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -3,7 +3,6 @@ import { DREAMER_AGENT } from "./agents/dreamer";
 import { HISTORIAN_AGENT, HISTORIAN_EDITOR_AGENT } from "./agents/historian";
 import {
     applyDisallowedTools,
-    buildAllowOnlyPermission,
     DREAMER_ALLOWED_TOOLS,
     HISTORIAN_ALLOWED_TOOLS,
     SIDEKICK_ALLOWED_TOOLS,
@@ -23,6 +22,7 @@ import {
 } from "./features/magic-context/storage-db";
 import { recordToolDefinition } from "./features/magic-context/tool-definition-tokens";
 import { runDeferredV22Backfill } from "./features/magic-context/v22-deferred-backfill";
+import { buildHiddenAgentConfig } from "./hidden-agent-config";
 import { createAutoUpdateCheckerHook } from "./hooks/auto-update-checker";
 import {
     COMPARTMENT_AGENT_SYSTEM_PROMPT,
@@ -51,47 +51,6 @@ import { MagicContextRpcServer } from "./shared/rpc-server";
 const HISTORIAN_MAX_STEPS = 40;
 const SIDEKICK_MAX_STEPS = 40;
 const DREAMER_MAX_STEPS = 150;
-
-function clampHiddenAgentStepLimit(value: unknown, cap: number): number {
-    return typeof value === "number" && Number.isFinite(value) ? Math.min(value, cap) : cap;
-}
-
-/**
- * Build a hidden-agent config with a deny-everything-by-default permission
- * baseline and a hard tool-iteration ceiling. User overrides may lower
- * `steps`/`maxSteps`, but cannot raise either above the built-in cap.
- */
-export function buildHiddenAgentConfig(
-    prompt: string,
-    allowedTools: readonly string[],
-    maxSteps: number,
-    overrides?: Record<string, unknown>,
-) {
-    const { permission: overridePermission, ...restOverrides } = (overrides ?? {}) as {
-        permission?: Record<string, unknown>;
-        [key: string]: unknown;
-    };
-    const basePermission = buildAllowOnlyPermission(allowedTools);
-    return {
-        prompt,
-        // No builtin fallback chain: the user's `fallback_models` (if any) flow
-        // through `restOverrides`. A hardcoded chain names providers the user may
-        // not have, producing `Model not found` retry storms.
-        ...restOverrides,
-        steps: clampHiddenAgentStepLimit(restOverrides.steps, maxSteps),
-        maxSteps: clampHiddenAgentStepLimit(restOverrides.maxSteps, maxSteps),
-        // Permission baseline goes after `restOverrides` so that accidental
-        // `permission` keys in user overrides we DIDN'T explicitly destructure
-        // can't bypass the deny. The explicit override (destructured above) is
-        // then layered on top.
-        permission: {
-            ...basePermission,
-            ...(overridePermission ?? {}),
-        },
-        mode: "subagent" as const,
-        hidden: true,
-    };
-}
 
 const plugin: Plugin = async (ctx) => {
     const pluginConfig = loadPluginConfig(ctx.directory);


### PR DESCRIPTION
## The bug

On opencode **1.17**, the magic-context plugin fails to load on every start:

```
level=ERROR message="failed to load plugin"
  path=…/magic-context/packages/plugin
  error="undefined is not an object (evaluating 'allowedTools')"
```

Consequences: no hooks or tools registered, empty MC runtime log, migration churn each boot, **all `ctx_*` tools dead**.

## Root cause

opencode 1.17 invokes **every exported function** in a plugin's entry module (`packages/plugin/src/index.ts`) as its own plugin factory — calling it `fn(ctx)`.

The helper `buildHiddenAgentConfig` is exported (introduced in `29a49cb6` "mason: apply D19 resilience safe parts"). So opencode calls it directly:

```
buildHiddenAgentConfig(ctx)        // prompt = ctx object, allowedTools = undefined
  → buildAllowOnlyPermission(undefined)
  → for (const tool of undefined)  // throws "undefined is not an object"
```

An instrumented stack trace confirmed the caller was opencode core (an Effect frame) invoking `buildHiddenAgentConfig` directly — not our own `config` hook. The DB (`PRAGMA quick_check: ok`) and the plugin cache were both empirically ruled out.

The entry module must export **only `default`** (the plugin factory). Any other exported function gets mis-invoked as a factory.

## The fix

Make `buildHiddenAgentConfig` module-local (remove `export`). It is only used inside `index.ts`, so this is safe.

Verified post-build:

```
dist export keys: ["default"]
```

…and the plugin loads cleanly under opencode 1.17 — hooks register, `ctx_*` tools are live, transforms run.

## Scope

One line (plus an explanatory comment so it isn't re-exported by reflex). `tsc` clean, build clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/magic-context/pr/182"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784837554&installation_id=135454708&pr_number=182&repository=cortexkit%2Fmagic-context&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Fmagic-context%2Fpull%2F182&signature=a62b3248c07c14f6f14034d1e7dc49b2bd20e7f887583f5d92480e15e5480016"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move `buildHiddenAgentConfig` out of the plugin entry to stop opencode 1.17 from invoking it as a plugin factory and crashing on load. The entry now exports only `default`, restoring clean startup and `ctx_*` tools.

- **Bug Fixes**
  - Moved `buildHiddenAgentConfig` to `packages/plugin/src/hidden-agent-config.ts` and imported it in `index.ts`; entry now exports only `default`.
  - Updated `index-refresh.test.ts` to use the new module; verified dist exports `['default']` and the plugin loads with hooks and tools active.

<sup>Written for commit d0a731f8cfe6180f7c82c0315061886da3f6de3b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/magic-context/pull/182?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a crash in opencode 1.17 where every exported function in a plugin entry module is invoked as a plugin factory. The previous code exported `buildHiddenAgentConfig` from `index.ts`, causing opencode to call it with a plugin context object as `prompt` and `undefined` as `allowedTools`, which threw on startup.

- **`packages/plugin/src/hidden-agent-config.ts`** (new): `buildHiddenAgentConfig` and `clampHiddenAgentStepLimit` are extracted into a standalone module with a JSDoc comment explaining why this helper must not live in the entry file.
- **`packages/plugin/src/index.ts`**: The function and its `buildAllowOnlyPermission` import are removed; the module now only exports `default`, resolving the mis-invocation.
- **`packages/plugin/src/index-refresh.test.ts`**: Test import updated from `./index` to `./hidden-agent-config`, keeping the existing unit tests intact.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a minimal, surgical extraction of one helper into its own module with no logic changes.

The function body is copied verbatim into `hidden-agent-config.ts`, the previously-broken test import is corrected in the same commit, and `index.ts` now carries only `export default plugin`. The fix directly addresses the confirmed crash path and leaves no other named exports in the entry module that opencode could mis-invoke.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/plugin/src/index.ts | Removed buildHiddenAgentConfig and the now-unused buildAllowOnlyPermission import; imports the helper from ./hidden-agent-config instead. Entry module now exports only `default`. |
| packages/plugin/src/hidden-agent-config.ts | New module containing buildHiddenAgentConfig and clampHiddenAgentStepLimit — identical logic to what was in index.ts, with an added JSDoc explaining the isolation requirement. |
| packages/plugin/src/index-refresh.test.ts | Import corrected from ./index to ./hidden-agent-config; test coverage for buildHiddenAgentConfig is preserved without changes to the assertions. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[opencode 1.17 loads plugin entry\npackages/plugin/src/index.ts] --> B{Iterates all\nexported keys}
    B -->|Before fix| C[Finds: default, buildHiddenAgentConfig]
    B -->|After fix| D[Finds: default only]
    C --> E[Calls buildHiddenAgentConfig as factory\nbuildHiddenAgentConfig ctx]
    E --> F[allowedTools = undefined\nfor...of undefined → CRASH\n'undefined is not an object']
    D --> G[Calls default plugin factory\nplugin ctx]
    G --> H[Plugin loads successfully\nhooks + ctx_* tools registered]
    style F fill:#ff4444,color:#fff
    style H fill:#22bb44,color:#fff
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[opencode 1.17 loads plugin entry\npackages/plugin/src/index.ts] --> B{Iterates all\nexported keys}
    B -->|Before fix| C[Finds: default, buildHiddenAgentConfig]
    B -->|After fix| D[Finds: default only]
    C --> E[Calls buildHiddenAgentConfig as factory\nbuildHiddenAgentConfig ctx]
    E --> F[allowedTools = undefined\nfor...of undefined → CRASH\n'undefined is not an object']
    D --> G[Calls default plugin factory\nplugin ctx]
    G --> H[Plugin loads successfully\nhooks + ctx_* tools registered]
    style F fill:#ff4444,color:#fff
    style H fill:#22bb44,color:#fff
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(plugin): move buildHiddenAgentConfig..."](https://github.com/cortexkit/magic-context/commit/d0a731f8cfe6180f7c82c0315061886da3f6de3b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39386618)</sub>

<!-- /greptile_comment -->