### PR TITLE
Override the default log file path by environment variable MAGIC_CONTEXT_LOG_PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ Magic Context also writes to a few other locations:
 |---|---|---|
 | `~/.local/share/cortexkit/magic-context/context.db` | SQLite database — tags, compartments, memories, all durable state (XDG-equivalent on Windows) | **Must persist.** Losing it loses your memory/history. |
 | `~/.local/share/cortexkit/magic-context/models/` | Local embedding model cache (~90 MB `Xenova/all-MiniLM-L6-v2` ONNX), downloaded on first use when local embeddings are enabled | Should persist, else re-downloaded each run. Not used when `memory.enabled: false` or an `openai_compatible`/`ollama` embedding backend is configured. |
-| `${TMPDIR}/opencode/magic-context/magic-context.log` (`pi/` for Pi) | Diagnostic log | Disposable. |
+| `MAGIC_CONTEXT_LOG_PATH` (fallback: `${TMPDIR}/opencode/magic-context/magic-context.log`, `pi/` for Pi) | Diagnostic log | Disposable. |
 
 **Sandboxed / ephemeral environments (Docker, CI, disposable containers):** mount the `~/.local/share/cortexkit/magic-context/` directory on a persistent volume so the database and model cache survive between runs. If only the model cache is ephemeral, the model is simply re-downloaded; if the database is ephemeral, memory and history don't accumulate. To avoid the ~90 MB model download entirely, set `memory.enabled: false` or point `embedding` at a remote `openai_compatible`/`ollama` backend.
 

--- a/packages/dashboard/README.md
+++ b/packages/dashboard/README.md
@@ -71,7 +71,7 @@ packages/dashboard/
 The dashboard reads from the same SQLite database the plugin writes to:
 - **Database**: `~/.local/share/cortexkit/magic-context/context.db`
 - **Config**: `~/.config/cortexkit/magic-context.jsonc` (user) · `<project>/.cortexkit/magic-context.jsonc` (project)
-- **Logs**: `${TMPDIR}/opencode/magic-context/magic-context.log` (`pi/` for Pi)
+- **Logs**: `MAGIC_CONTEXT_LOG_PATH` (fallback: `${TMPDIR}/opencode/magic-context/magic-context.log`, `pi/` for Pi)
 
 Database access uses WAL mode for safe concurrent reads while the plugin writes. Write operations (memory edits, dream queue entries) use `busy_timeout` to handle contention.
 

--- a/packages/dashboard/src-tauri/src/log_parser.rs
+++ b/packages/dashboard/src-tauri/src/log_parser.rs
@@ -33,6 +33,14 @@ impl Harness {
 /// in sync manually because the dashboard doesn't import any TypeScript
 /// source.
 pub fn resolve_log_path_for(harness: Harness) -> PathBuf {
+    if let Some(env_path) = std::env::var("MAGIC_CONTEXT_LOG_PATH")
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+    {
+        return PathBuf::from(env_path);
+    }
+
     std::env::temp_dir()
         .join(harness.as_str())
         .join("magic-context")
@@ -435,4 +443,77 @@ pub fn read_log_tail(path: &PathBuf, max_lines: usize) -> Vec<LogEntry> {
         .iter()
         .filter_map(|line| parse_log_line(line))
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{resolve_log_path_for, Harness};
+    use std::path::PathBuf;
+    use std::sync::{Mutex, OnceLock};
+
+    static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+    fn env_lock() -> std::sync::MutexGuard<'static, ()> {
+        ENV_LOCK
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+    }
+
+    #[test]
+    fn resolve_log_path_for_uses_harness_fallback_when_env_unset() {
+        let _guard = env_lock();
+        std::env::remove_var("MAGIC_CONTEXT_LOG_PATH");
+
+        assert_eq!(
+            resolve_log_path_for(Harness::Opencode),
+            std::env::temp_dir()
+                .join("opencode")
+                .join("magic-context")
+                .join("magic-context.log")
+        );
+        assert_eq!(
+            resolve_log_path_for(Harness::Pi),
+            std::env::temp_dir()
+                .join("pi")
+                .join("magic-context")
+                .join("magic-context.log")
+        );
+    }
+
+    #[test]
+    fn resolve_log_path_for_honors_magic_context_log_path_override() {
+        let _guard = env_lock();
+        let custom = std::env::temp_dir()
+            .join("custom")
+            .join("magic-context.log");
+        std::env::set_var(
+            "MAGIC_CONTEXT_LOG_PATH",
+            custom.to_string_lossy().to_string(),
+        );
+
+        assert_eq!(
+            resolve_log_path_for(Harness::Opencode),
+            PathBuf::from(&custom)
+        );
+        assert_eq!(resolve_log_path_for(Harness::Pi), PathBuf::from(&custom));
+
+        std::env::remove_var("MAGIC_CONTEXT_LOG_PATH");
+    }
+
+    #[test]
+    fn resolve_log_path_for_ignores_blank_magic_context_log_path() {
+        let _guard = env_lock();
+        std::env::set_var("MAGIC_CONTEXT_LOG_PATH", "   ");
+
+        assert_eq!(
+            resolve_log_path_for(Harness::Pi),
+            std::env::temp_dir()
+                .join("pi")
+                .join("magic-context")
+                .join("magic-context.log")
+        );
+
+        std::env::remove_var("MAGIC_CONTEXT_LOG_PATH");
+    }
 }

--- a/packages/docs/src/content/docs/reference/dashboard.md
+++ b/packages/docs/src/content/docs/reference/dashboard.md
@@ -148,4 +148,4 @@ Use [Configuration](/reference/configuration/) for the full generated key refere
 
 ## Logs
 
-Optional **log tail** for `magic-context.log` with filtering, useful alongside Cache when correlating busts with plugin log lines.
+Optional **log tail** for `MAGIC_CONTEXT_LOG_PATH` (fallback: `${TMPDIR}/opencode/magic-context/magic-context.log`, `pi/` for Pi) with filtering — useful alongside Cache when correlating busts with plugin log lines. Open from the sidebar **Logs** item.

--- a/packages/plugin/src/features/magic-context/dreamer/task-executor.ts
+++ b/packages/plugin/src/features/magic-context/dreamer/task-executor.ts
@@ -91,7 +91,6 @@ export interface DreamTaskExecutorDeps {
     ) => Promise<RawMessageProvider | null> | RawMessageProvider | null;
     language?: string;
 }
-
 /** A failed task either hot-retries (transient: provider/network/rate-limit/
  *  timeout/abort/lease/busy) or advances to the next cron slot (permanent:
  *  model-not-found, validation, parse). Classify off the error shape. */

--- a/packages/plugin/src/features/magic-context/storage-schema-helpers.ts
+++ b/packages/plugin/src/features/magic-context/storage-schema-helpers.ts
@@ -1,4 +1,4 @@
-import { Database } from "../../shared/sqlite";
+import type { Database } from "../../shared/sqlite";
 
 /**
  * Schema-mutation helpers shared by storage-db (fresh-DB init) and migrations

--- a/packages/plugin/src/shared/data-path.test.ts
+++ b/packages/plugin/src/shared/data-path.test.ts
@@ -7,6 +7,7 @@ import {
     getCacheDir,
     getDataDir,
     getLegacyOpenCodeMagicContextStorageDir,
+    getMagicContextLogPath,
     getMagicContextStorageDir,
     getOpenCodeCacheDir,
     getOpenCodeStorageDir,
@@ -18,6 +19,7 @@ const savedEnv = {
     XDG_CACHE_HOME: process.env.XDG_CACHE_HOME,
     XDG_DATA_HOME: process.env.XDG_DATA_HOME,
     LOCALAPPDATA: process.env.LOCALAPPDATA,
+    MAGIC_CONTEXT_LOG_PATH: process.env.MAGIC_CONTEXT_LOG_PATH,
 };
 
 describe("data-path", () => {
@@ -25,10 +27,12 @@ describe("data-path", () => {
         process.env.XDG_CACHE_HOME = undefined;
         process.env.XDG_DATA_HOME = undefined;
         process.env.LOCALAPPDATA = undefined;
+        process.env.MAGIC_CONTEXT_LOG_PATH = undefined;
         // Bun's env handling: explicit delete for unset
         delete process.env.XDG_CACHE_HOME;
         delete process.env.XDG_DATA_HOME;
         delete process.env.LOCALAPPDATA;
+        delete process.env.MAGIC_CONTEXT_LOG_PATH;
     });
 
     afterEach(() => {
@@ -37,6 +41,9 @@ describe("data-path", () => {
         if (savedEnv.XDG_DATA_HOME !== undefined)
             process.env.XDG_DATA_HOME = savedEnv.XDG_DATA_HOME;
         if (savedEnv.LOCALAPPDATA !== undefined) process.env.LOCALAPPDATA = savedEnv.LOCALAPPDATA;
+        if (savedEnv.MAGIC_CONTEXT_LOG_PATH !== undefined)
+            process.env.MAGIC_CONTEXT_LOG_PATH = savedEnv.MAGIC_CONTEXT_LOG_PATH;
+        else delete process.env.MAGIC_CONTEXT_LOG_PATH;
     });
 
     test("getCacheDir falls back to <homedir>/.cache when XDG_CACHE_HOME is unset (all platforms)", () => {
@@ -156,6 +163,24 @@ describe("data-path", () => {
         // worry about how the project directory was constructed.
         expect(getProjectMagicContextDir("/some/project/")).toBe(
             path.join("/some/project/", ".cortexkit", "magic-context"),
+        );
+    });
+
+    test("getMagicContextLogPath falls back to harness temp dir when env unset", () => {
+        expect(getMagicContextLogPath("opencode")).toBe(
+            path.join(os.tmpdir(), "opencode", "magic-context", "magic-context.log"),
+        );
+    });
+
+    test("getMagicContextLogPath honors MAGIC_CONTEXT_LOG_PATH", () => {
+        process.env.MAGIC_CONTEXT_LOG_PATH = "/tmp/custom/magic-context.log";
+        expect(getMagicContextLogPath("pi")).toBe("/tmp/custom/magic-context.log");
+    });
+
+    test("getMagicContextLogPath ignores blank MAGIC_CONTEXT_LOG_PATH", () => {
+        process.env.MAGIC_CONTEXT_LOG_PATH = "   ";
+        expect(getMagicContextLogPath("pi")).toBe(
+            path.join(os.tmpdir(), "pi", "magic-context", "magic-context.log"),
         );
     });
 });

--- a/packages/plugin/src/shared/data-path.ts
+++ b/packages/plugin/src/shared/data-path.ts
@@ -46,6 +46,8 @@ export function getMagicContextTempDir(harness: HarnessId = getHarness()): strin
  * reflected in the next flush.
  */
 export function getMagicContextLogPath(harness: HarnessId = getHarness()): string {
+    const envPath = process.env.MAGIC_CONTEXT_LOG_PATH?.trim();
+    if (envPath) return envPath;
     return path.join(getMagicContextTempDir(harness), "magic-context.log");
 }
 


### PR DESCRIPTION
<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/magic-context/pr/183"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784889657&installation_id=135454708&pr_number=183&repository=cortexkit%2Fmagic-context&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Fmagic-context%2Fpull%2F183&signature=f38ff40a9ed40923196f155380c332f9b02fb6c184ab7563ce4aa5ed2d67f9d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow overriding the Magic Context log file path via `MAGIC_CONTEXT_LOG_PATH`. Both the plugin and dashboard trim and ignore blank values, defaulting to `${TMPDIR}/<harness>/magic-context/magic-context.log`.

- **New Features**
  - `packages/plugin`: `getMagicContextLogPath` reads trimmed `MAGIC_CONTEXT_LOG_PATH` with harness-temp fallback.
  - `packages/dashboard`: `resolve_log_path_for` mirrors the override; docs updated in `README.md`, dashboard `README.md`, and docs reference.

- **Bug Fixes**
  - `packages/dashboard`: Tests serialize env var mutations with a `OnceLock<Mutex>` to avoid parallel races; cover override, blank, and fallback.
  - `packages/plugin`: Added tests for unset, override, and blank in `getMagicContextLogPath`.

<sup>Written for commit 2ae175f38148512da0a3e669caafc28b1c7c64f7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/magic-context/pull/183?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds `MAGIC_CONTEXT_LOG_PATH` environment variable support to override the default per-harness log file path in both the TypeScript plugin and Rust dashboard; when unset or blank, both sides fall back to the existing `${TMPDIR}/<harness>/magic-context/magic-context.log` layout.

- **Plugin (`data-path.ts`)**: `getMagicContextLogPath` now reads, trims, and honors `MAGIC_CONTEXT_LOG_PATH` before falling back to the harness-based temp path; three new tests cover unset, override, and blank-string cases.
- **Dashboard (`log_parser.rs`)**: `resolve_log_path_for` mirrors the same logic in Rust, with tests serialized via a `OnceLock<Mutex<()>>` guard to prevent env-mutation races.
- **Docs / READMEs**: All three documentation files updated to surface `MAGIC_CONTEXT_LOG_PATH` and its fallback behaviour.
</details>


<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a small, well-tested additive feature with no modifications to existing logic.

Both the TypeScript and Rust implementations follow the same trim-and-fallback pattern, the env-mutation race condition raised in a prior review has been properly addressed with a shared mutex, and all three test suites cover the unset, override, and blank-whitespace cases. No existing call sites are affected.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/plugin/src/shared/data-path.ts | Adds two-line env-var override to getMagicContextLogPath; logic is clean and symmetric with the Rust implementation. |
| packages/dashboard/src-tauri/src/log_parser.rs | resolve_log_path_for gains MAGIC_CONTEXT_LOG_PATH override; tests now serialized with OnceLock<Mutex<()>>, addressing prior race-condition concern. |
| packages/plugin/src/shared/data-path.test.ts | Three new tests cover unset, override, and blank env var cases with proper save/restore of MAGIC_CONTEXT_LOG_PATH. |
| packages/plugin/src/features/magic-context/storage-schema-helpers.ts | Type-only import cleanup (import { Database } → import type { Database }); no logic change. |
| README.md | Doc table updated to show MAGIC_CONTEXT_LOG_PATH with harness-specific fallbacks. |

</details>


<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Call getMagicContextLogPath / resolve_log_path_for] --> B{MAGIC_CONTEXT_LOG_PATH set?}
    B -- "Yes (non-blank after trim)" --> C[Return env var value as path]
    B -- "No / blank / whitespace-only" --> D{Which harness?}
    D -- opencode --> E["${TMPDIR}/opencode/magic-context/magic-context.log"]
    D -- pi --> F["${TMPDIR}/pi/magic-context/magic-context.log"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Call getMagicContextLogPath / resolve_log_path_for] --> B{MAGIC_CONTEXT_LOG_PATH set?}
    B -- "Yes (non-blank after trim)" --> C[Return env var value as path]
    B -- "No / blank / whitespace-only" --> D{Which harness?}
    D -- opencode --> E["${TMPDIR}/opencode/magic-context/magic-context.log"]
    D -- pi --> F["${TMPDIR}/pi/magic-context/magic-context.log"]
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/plugin/src/shared/data-path.ts`, line 39-46 ([link](https://github.com/cortexkit/magic-context/blob/706d9cc2d7d506345e07e23a0612d1492546a76e/packages/plugin/src/shared/data-path.ts#L39-L46)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The JSDoc still says "Pi and OpenCode write to SEPARATE logs under their respective harness subtrees" — but that guarantee is now broken when `MAGIC_CONTEXT_LOG_PATH` is set. Both harnesses will resolve to the same file, interleaving their session traces. The comment should be updated to reflect the override, and users should be warned about this behaviour.
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (5): Last reviewed commit: ["Override the default log file path by en..."](https://github.com/cortexkit/magic-context/commit/2ae175f38148512da0a3e669caafc28b1c7c64f7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39527883)</sub>

<!-- /greptile_comment -->