### PR TITLE
test: reproduce large→small model-switch overflow (GLM-5.2 512k → GPT-5.5 272k)

### DIFF
--- a/packages/plugin/src/hooks/magic-context/transform.test.ts
+++ b/packages/plugin/src/hooks/magic-context/transform.test.ts
@@ -23,6 +23,7 @@ import {
     getLastNudgeUndropped,
     getOrCreateSessionMeta,
     getPendingOps,
+    getOverflowState,
     getTagById,
     getTagsBySession,
     incrementHistorianFailure,
@@ -2544,5 +2545,128 @@ describe("createTransform historian failure handling", () => {
         await new Promise((resolve) => setTimeout(resolve, 0));
 
         expect(createSession).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe("createTransform model switch large→small context", () => {
+    it("arms emergency recovery when switching from a large-context to a small-context model that would overflow", async () => {
+        // Reproduces: user switches from GLM-5.2 (512k) to GPT-5.5 (272k).
+        // The session had ~300k input tokens on the old model (~58% of 512k —
+        // well under any trigger threshold). After the switch, that same 300k
+        // is ~110% of the new 272k limit — a guaranteed overflow.
+        //
+        // The model-change branch (transform.ts:502) detects the switch and
+        // currently clears lastContextPercentage / lastInputTokens to 0. This
+        // suppresses every reduction path:
+        //   - historian trigger: 0% < proactive floor → shouldFire=false
+        //   - 95% emergency block: 0% < 95% → no block
+        //   - overflow recovery bump: needsEmergencyRecovery was just cleared
+        // The oversized prompt is sent to the small model → "Input exceeds
+        // context window" error. Recovery only fires on the SECOND pass (after
+        // the real overflow error arms needsEmergencyRecovery via the event
+        // handler). The user sees the error on the first request.
+        //
+        // Expected behavior: when the model-change branch detects that the old
+        // model's lastInputTokens exceed the NEW model's context limit, it
+        // should arm emergency recovery (recordOverflowDetected with the new
+        // limit) so the existing bump-to-95% path fires on the SAME pass —
+        // historian + emergency drops run BEFORE the prompt is sent.
+        //#given
+        useTempDataHome("transform-model-switch-large-small-");
+        const sessionId = "ses-model-shrink";
+        createOpenCodeDbForTransform(sessionId, [
+            { id: "m-raw-1", role: "user", text: "earlier work" },
+            {
+                id: "m-raw-assistant-old",
+                role: "assistant",
+                text: "old model response",
+                providerID: "openrouter",
+                modelID: "z-ai/glm-5.2",
+            },
+            { id: "m-raw-2", role: "user", text: "continue" },
+        ]);
+        const db = openDatabase();
+        // Persist the old model's usage: 300k input tokens at 58% of 512k.
+        // This is a realistic mid-session state — high token mass, moderate
+        // pressure, no historian fire yet.
+        updateSessionMeta(db, sessionId, {
+            lastContextPercentage: 58,
+            lastInputTokens: 300_000,
+            lastObservedModelKey: "openrouter/z-ai/glm-5.2",
+            lastUsageContextLimit: 512_000,
+        });
+
+        // The NEW model (GPT-5.5, 272k) is already in liveModelBySession —
+        // simulating that hook-handlers.ts set it on the chat.message event
+        // before this transform pass.
+        const liveModelBySession = new Map<string, { providerID: string; modelID: string }>([
+            [sessionId, { providerID: "openrouter", modelID: "openai/gpt-5.5" }],
+        ]);
+
+        const scheduler: Scheduler = { shouldExecute: mock(() => "defer" as const) };
+        const transform = createTransform({
+            tagger: createTagger(),
+            scheduler,
+            contextUsageMap: new Map<string, { usage: ContextUsage; updatedAt: number }>([
+                [
+                    sessionId,
+                    {
+                        usage: { percentage: 58, inputTokens: 300_000 },
+                        updatedAt: Date.now(),
+                    },
+                ],
+            ]),
+            db,
+            historyRefreshSessions: new Set<string>(),
+            pendingMaterializationSessions: new Set<string>(),
+            lastHeuristicsTurnId: new Map<string, string>(),
+            clearReasoningAge: 50,
+            protectedTags: 0,
+            liveModelBySession,
+        });
+
+        // The messages array: last assistant is from the OLD model (GLM-5.2).
+        // The transform's findLastAssistantModel will return GLM-5.2, which
+        // mismatches liveModelBySession (GPT-5.5) → model-change branch fires.
+        // The large tool output (~50k tokens) represents content that, combined
+        // with the rest of the 300k-token context, would overflow the new 272k
+        // model — but is NOT individually droppable at 0% pressure.
+        const bigOutput = "const value = compute(input, options); // step output line\n".repeat(
+            3400,
+        );
+        const messages: TestMessage[] = [
+            {
+                info: { id: "m-user", role: "user", sessionID: sessionId },
+                parts: [{ type: "text", text: "continue" }],
+            },
+            {
+                info: {
+                    id: "m-assistant-old",
+                    role: "assistant",
+                    providerID: "openrouter",
+                    modelID: "z-ai/glm-5.2",
+                },
+                parts: [
+                    { type: "text", text: "ok" },
+                    { type: "tool", callID: "call-1", state: { output: bigOutput } },
+                ],
+            },
+        ];
+
+        //#when
+        await transform({}, { messages });
+
+        //#then — the model-change branch armed emergency recovery on this pass
+        // (oldInputTokens 300k > new 272k limit), so the 95% bump path fired
+        // and the historian/emergency-drop machinery ran BEFORE the prompt left.
+        const overflow = getOverflowState(db, sessionId);
+        expect(overflow.needsEmergencyRecovery).toBe(true);
+
+        // The oversized tool output was dropped by the emergency drop path that
+        // the 95% bump armed — it's no longer on the wire that would overflow
+        // the new model.
+        const tags = getTagsBySession(db, sessionId);
+        const toolTag = tags.find((tag) => tag.type === "tool");
+        expect(toolTag?.status).toBe("dropped");
     });
 });


### PR DESCRIPTION
## Bug

When switching from a large-context model to a smaller one mid-session (e.g. GLM-5.2 512k → GPT-5.5 272k), the historian does not reduce the context to fit the new model before sending the prompt, resulting in `Input exceeds context window` errors.

## Root cause

The model-change branch in `transform.ts:502-547` detects the switch and clears `lastContextPercentage` / `lastInputTokens` to 0. This suppresses every reduction path on the same pass:

- **Historian trigger** (`checkCompartmentTrigger`): 0% < proactive floor → `shouldFire=false`
- **95% emergency block** (`transform-compartment-phase.ts:328`): 0% < 95% → no block
- **Overflow recovery bump** (`transform.ts:616-628`): `needsEmergencyRecovery` was just cleared → no bump

The oversized prompt — sized for the old model's window — is sent to the new smaller model and rejected. Recovery only arms on the **second** pass, after the real overflow error fires the event handler's `recordOverflowDetected`. The user sees the error on the first request.

## Fix direction

In the model-change branch (`transform.ts:502`), before clearing, compare `sessionMeta.lastInputTokens` (the old model's last measured input tokens) against the new model's context limit (`resolveTrustedContextLimit`). When `oldInputTokens > newContextLimit`, call `recordOverflowDetected(db, sessionId, newContextLimit, newModelKey)` to arm recovery — which makes the existing `:616-628` bump-to-95% path fire on the **same pass**, so historian + emergency drops run before the prompt is sent.

## Reproduction

This PR adds a failing test (`transform.test.ts`) reproducing the scenario:
- Session at 300k input tokens on GLM-5.2 (58% of 512k — no trigger fired)
- Switch to GPT-5.5 (272k) — 300k is ~110% of the new window
- Asserts `needsEmergencyRecovery === true` and the oversized tool output is dropped

The test currently fails: `needsEmergencyRecovery` is `false` and the tool output stays `active`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/magic-context/pr/187"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784958891&installation_id=135454708&pr_number=187&repository=cortexkit%2Fmagic-context&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Fmagic-context%2Fpull%2F187&signature=bd00a74d7fed272b79de5ea3e5d55397a3ce4e77efa90ee5e7326f9d3a1a1252"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a failing test in `packages/plugin/src/hooks/magic-context/transform.test.ts` that reproduces an overflow when switching mid-session from a large-context model (GLM-5.2 512k) to a smaller one (GPT-5.5 272k).
The test expects emergency recovery to arm immediately and drop oversized tool output before send; it currently fails, confirming the model-change branch clears usage and allows an oversized prompt through.

<sup>Written for commit 7105f3ff259488889d4ff88aaba1cc21f4eef17f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/magic-context/pull/187?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a single failing test that documents the large→small model-switch overflow bug: when a session built up 300k tokens on GLM-5.2 (512k) is switched to GPT-5.5 (272k), the model-change branch in `transform.ts` clears all pressure state to zero, which suppresses every reduction path so the oversized prompt is sent to the new smaller model unchanged.

- The test correctly reproduces the bug mechanism — `liveModelBySession` holds the new model while the last assistant message still carries the old model, triggering the model-change branch, and the session meta carries `lastInputTokens: 300_000` against a 272k new window.
- Two structural problems prevent the test from turning green once the fix lands: the test does not write a synthetic `models.json` with GPT-5.5's context limit (so `resolveTrustedContextLimit` returns `undefined` and the fix's overflow comparison never fires), and the OpenCode DB is seeded with `id: \"m-raw-assistant-old\"` while the live messages array uses `id: \"m-assistant-old\"` (a cross-reference mismatch that can affect message-index reconciliation and tool-tag eligibility).
</details>

<h3>Confidence Score: 2/5</h3>

The test is safe to merge in isolation — no production code is touched — but as written it will not turn green when the corresponding fix lands, leaving CI in a permanently failing state for this case.

The test correctly identifies the bug and the right observable outcomes, but cannot fulfill its role as a reproducer: without a models.json fixture carrying GPT-5.5's context limit, the fix mechanism gets undefined for the new model and skips arming recovery entirely. A separate OpenCode DB / live-messages ID mismatch could cause the tool-tag assertion to fail for an unrelated reason even if recovery were somehow armed. Both issues need to be resolved before the test can serve as a reliable regression guard.

packages/plugin/src/hooks/magic-context/transform.test.ts — specifically the new describe block starting at line 2551.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/plugin/src/hooks/magic-context/transform.test.ts | Adds a failing regression test for the large→small model-switch overflow bug; has two blocking structural issues: no synthetic models.json mock for GPT-5.5 (so resolveTrustedContextLimit returns undefined and the proposed fix never arms recovery), and an OpenCode DB message ID mismatch (m-raw-assistant-old vs m-assistant-old in the live messages array) that could break tool-tag eligibility checks. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant TF as transform.ts
    participant MC as model-change branch (502-547)
    participant OVF as overflow state (DB)
    participant LCU as loadContextUsage
    participant BUMP as 95% bump path (616-628)
    participant ED as emergency-drop

    TF->>MC: "liveModel=GPT-5.5, lastAssistant=GLM-5.2 → mismatch"
    MC->>OVF: clearEmergencyRecovery()
    MC->>MC: contextUsageMap.delete(sessionId)
    Note over MC: (BUG) no recordOverflowDetected called
    Note over MC: (FIX) resolveTrustedContextLimit(GPT-5.5)<br/>needs models.json mock — returns undefined without it
    MC->>LCU: loadContextUsage → 0%
    LCU-->>TF: "percentage=0%"
    TF->>OVF: "getOverflowState → needsEmergencyRecovery=false"
    Note over BUMP: 0% < 95% but needsEmergencyRecovery=false → no bump
    TF->>ED: skipped — no 95% bump
    Note over ED: tool output stays active → prompt sent oversized → overflow error
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant TF as transform.ts
    participant MC as model-change branch (502-547)
    participant OVF as overflow state (DB)
    participant LCU as loadContextUsage
    participant BUMP as 95% bump path (616-628)
    participant ED as emergency-drop

    TF->>MC: "liveModel=GPT-5.5, lastAssistant=GLM-5.2 → mismatch"
    MC->>OVF: clearEmergencyRecovery()
    MC->>MC: contextUsageMap.delete(sessionId)
    Note over MC: (BUG) no recordOverflowDetected called
    Note over MC: (FIX) resolveTrustedContextLimit(GPT-5.5)<br/>needs models.json mock — returns undefined without it
    MC->>LCU: loadContextUsage → 0%
    LCU-->>TF: "percentage=0%"
    TF->>OVF: "getOverflowState → needsEmergencyRecovery=false"
    Note over BUMP: 0% < 95% but needsEmergencyRecovery=false → no bump
    TF->>ED: skipped — no 95% bump
    Note over ED: tool output stays active → prompt sent oversized → overflow error
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["test: reproduce large→small model-switch..."](https://github.com/cortexkit/magic-context/commit/7105f3ff259488889d4ff88aaba1cc21f4eef17f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39757205)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->