### PR TITLE
Fix stale OpenCode plugin cache doctor check

### DIFF
--- a/packages/cli/src/adapters/opencode.ts
+++ b/packages/cli/src/adapters/opencode.ts
@@ -4,6 +4,11 @@ import { parse as parseJsonc, stringify as stringifyJsonc } from "comment-json";
 import { writeFileAtomic } from "../lib/atomic-write";
 import { isOpenCodeInstalledOnSystem } from "../lib/opencode-install";
 import {
+    getOpenCodePluginPackageJsonPaths,
+    OPENCODE_PLUGIN_ENTRY_WITH_VERSION as PLUGIN_ENTRY,
+    OPENCODE_PLUGIN_NAME as PLUGIN_NAME,
+} from "../lib/opencode-plugin-cache";
+import {
     detectConfigPaths,
     dirSizeBytes,
     getMagicContextLogPath,
@@ -15,9 +20,6 @@ import type {
     PluginCacheInfo,
     PluginEntryResult,
 } from "./types";
-
-const PLUGIN_NAME = "@cortexkit/opencode-magic-context";
-const PLUGIN_ENTRY = `${PLUGIN_NAME}@latest`;
 
 export class OpenCodeAdapter implements HarnessAdapter {
     readonly kind = "opencode" as const;
@@ -214,12 +216,7 @@ export class OpenCodeAdapter implements HarnessAdapter {
 
     getInstalledPluginVersion(): string | null {
         // Look in OpenCode's plugin cache for the installed package version.
-        const cacheDir = getOpenCodePluginCacheDir();
-        const candidates = [
-            `${cacheDir}/${PLUGIN_NAME}@latest/node_modules/${PLUGIN_NAME}/package.json`,
-            `${cacheDir}/${PLUGIN_NAME}/node_modules/${PLUGIN_NAME}/package.json`,
-        ];
-        for (const candidate of candidates) {
+        for (const candidate of getOpenCodePluginPackageJsonPaths()) {
             if (!existsSync(candidate)) continue;
             try {
                 const raw = readFileSync(candidate, "utf-8");

--- a/packages/cli/src/commands/doctor-opencode-cache.ts
+++ b/packages/cli/src/commands/doctor-opencode-cache.ts
@@ -1,0 +1,83 @@
+import { existsSync, readFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { getOpenCodeCacheDir } from "@magic-context/core/shared/data-path";
+
+const PLUGIN_NAME = "@cortexkit/opencode-magic-context";
+const PLUGIN_ENTRY_WITH_VERSION = `${PLUGIN_NAME}@latest`;
+
+export interface PluginCacheResult {
+    action: "cleared" | "up_to_date" | "not_found" | "error";
+    path: string;
+    cached?: string;
+    latest?: string;
+    error?: string;
+}
+
+export function getOpenCodePluginCacheRoots(): string[] {
+    const cacheDir = getOpenCodeCacheDir();
+    return [
+        join(cacheDir, "packages", PLUGIN_ENTRY_WITH_VERSION),
+        join(cacheDir, "packages", PLUGIN_NAME),
+    ];
+}
+
+function cachedPluginPackagePath(pluginCacheDir: string): string {
+    return join(
+        pluginCacheDir,
+        "node_modules",
+        "@cortexkit",
+        "opencode-magic-context",
+        "package.json",
+    );
+}
+
+function readCachedPluginVersion(pluginCacheDir: string): string | undefined {
+    try {
+        const installedPkgPath = cachedPluginPackagePath(pluginCacheDir);
+        if (!existsSync(installedPkgPath)) return undefined;
+        const pkg = JSON.parse(readFileSync(installedPkgPath, "utf-8")) as { version?: unknown };
+        return typeof pkg.version === "string" ? pkg.version : undefined;
+    } catch {
+        return undefined;
+    }
+}
+
+export async function clearPluginCache(
+    options: { force?: boolean; latestVersion?: string | null } = {},
+): Promise<PluginCacheResult> {
+    const [pluginCacheDir] = getOpenCodePluginCacheRoots();
+
+    if (!existsSync(pluginCacheDir)) {
+        return { action: "not_found", path: pluginCacheDir };
+    }
+
+    const cachedVersion = readCachedPluginVersion(pluginCacheDir);
+    const latestVersion = options.latestVersion ?? undefined;
+
+    if (
+        options.force !== true &&
+        cachedVersion &&
+        latestVersion &&
+        cachedVersion === latestVersion
+    ) {
+        return {
+            action: "up_to_date",
+            path: pluginCacheDir,
+            cached: cachedVersion,
+            latest: latestVersion,
+        };
+    }
+
+    try {
+        rmSync(pluginCacheDir, { recursive: true, force: true });
+        return {
+            action: "cleared",
+            path: pluginCacheDir,
+            cached: cachedVersion,
+            latest: latestVersion,
+        };
+    } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : String(err);
+        return { action: "error", path: pluginCacheDir, error: message };
+    }
+}

--- a/packages/cli/src/commands/doctor-opencode-cache.ts
+++ b/packages/cli/src/commands/doctor-opencode-cache.ts
@@ -1,12 +1,11 @@
 import { existsSync, readFileSync, rmSync } from "node:fs";
-import { join } from "node:path";
-import { getOpenCodeCacheDir } from "@magic-context/core/shared/data-path";
-
-export const OPENCODE_PLUGIN_NAME = "@cortexkit/opencode-magic-context";
-export const OPENCODE_PLUGIN_ENTRY_WITH_VERSION = `${OPENCODE_PLUGIN_NAME}@latest`;
+import {
+    getOpenCodePluginCacheRoots,
+    getOpenCodePluginPackageJsonPath,
+} from "../lib/opencode-plugin-cache";
 
 export interface PluginCacheResult {
-    action: "cleared" | "up_to_date" | "not_found" | "error";
+    action: "cleared" | "up_to_date" | "not_found" | "check_unavailable" | "error";
     path: string;
     paths?: string[];
     cached?: string;
@@ -14,27 +13,9 @@ export interface PluginCacheResult {
     error?: string;
 }
 
-export function getOpenCodePluginCacheRoots(): string[] {
-    const cacheDir = getOpenCodeCacheDir();
-    return [
-        join(cacheDir, "packages", OPENCODE_PLUGIN_ENTRY_WITH_VERSION),
-        join(cacheDir, "packages", OPENCODE_PLUGIN_NAME),
-    ];
-}
-
-function cachedPluginPackagePath(pluginCacheDir: string): string {
-    return join(
-        pluginCacheDir,
-        "node_modules",
-        "@cortexkit",
-        "opencode-magic-context",
-        "package.json",
-    );
-}
-
 function readCachedPluginVersion(pluginCacheDir: string): string | undefined {
     try {
-        const installedPkgPath = cachedPluginPackagePath(pluginCacheDir);
+        const installedPkgPath = getOpenCodePluginPackageJsonPath(pluginCacheDir);
         if (!existsSync(installedPkgPath)) return undefined;
         const pkg = JSON.parse(readFileSync(installedPkgPath, "utf-8")) as { version?: unknown };
         return typeof pkg.version === "string" ? pkg.version : undefined;
@@ -58,12 +39,20 @@ export async function clearPluginCache(
         path,
         cached: readCachedPluginVersion(path),
     }));
+
+    if (options.force !== true && latestVersion === undefined) {
+        const firstEntry = cacheEntries[0];
+        return {
+            action: "check_unavailable",
+            path: firstEntry?.path ?? pluginCacheRoots[0] ?? "",
+            paths: cacheEntries.map((entry) => entry.path),
+            cached: firstEntry?.cached,
+        };
+    }
+
     const clearTargets = cacheEntries.filter(
         (entry) =>
-            options.force === true ||
-            latestVersion === undefined ||
-            entry.cached === undefined ||
-            entry.cached !== latestVersion,
+            options.force === true || entry.cached === undefined || entry.cached !== latestVersion,
     );
 
     if (clearTargets.length === 0) {

--- a/packages/cli/src/commands/doctor-opencode-cache.ts
+++ b/packages/cli/src/commands/doctor-opencode-cache.ts
@@ -2,12 +2,13 @@ import { existsSync, readFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { getOpenCodeCacheDir } from "@magic-context/core/shared/data-path";
 
-const PLUGIN_NAME = "@cortexkit/opencode-magic-context";
-const PLUGIN_ENTRY_WITH_VERSION = `${PLUGIN_NAME}@latest`;
+export const OPENCODE_PLUGIN_NAME = "@cortexkit/opencode-magic-context";
+export const OPENCODE_PLUGIN_ENTRY_WITH_VERSION = `${OPENCODE_PLUGIN_NAME}@latest`;
 
 export interface PluginCacheResult {
     action: "cleared" | "up_to_date" | "not_found" | "error";
     path: string;
+    paths?: string[];
     cached?: string;
     latest?: string;
     error?: string;
@@ -16,8 +17,8 @@ export interface PluginCacheResult {
 export function getOpenCodePluginCacheRoots(): string[] {
     const cacheDir = getOpenCodeCacheDir();
     return [
-        join(cacheDir, "packages", PLUGIN_ENTRY_WITH_VERSION),
-        join(cacheDir, "packages", PLUGIN_NAME),
+        join(cacheDir, "packages", OPENCODE_PLUGIN_ENTRY_WITH_VERSION),
+        join(cacheDir, "packages", OPENCODE_PLUGIN_NAME),
     ];
 }
 
@@ -45,39 +46,55 @@ function readCachedPluginVersion(pluginCacheDir: string): string | undefined {
 export async function clearPluginCache(
     options: { force?: boolean; latestVersion?: string | null } = {},
 ): Promise<PluginCacheResult> {
-    const [pluginCacheDir] = getOpenCodePluginCacheRoots();
+    const pluginCacheRoots = getOpenCodePluginCacheRoots();
+    const existingRoots = pluginCacheRoots.filter((root) => existsSync(root));
 
-    if (!existsSync(pluginCacheDir)) {
-        return { action: "not_found", path: pluginCacheDir };
+    if (existingRoots.length === 0) {
+        return { action: "not_found", path: pluginCacheRoots[0] ?? "" };
     }
 
-    const cachedVersion = readCachedPluginVersion(pluginCacheDir);
     const latestVersion = options.latestVersion ?? undefined;
+    const cacheEntries = existingRoots.map((path) => ({
+        path,
+        cached: readCachedPluginVersion(path),
+    }));
+    const clearTargets = cacheEntries.filter(
+        (entry) =>
+            options.force === true ||
+            latestVersion === undefined ||
+            entry.cached === undefined ||
+            entry.cached !== latestVersion,
+    );
 
-    if (
-        options.force !== true &&
-        cachedVersion &&
-        latestVersion &&
-        cachedVersion === latestVersion
-    ) {
+    if (clearTargets.length === 0) {
+        const firstEntry = cacheEntries[0];
         return {
             action: "up_to_date",
-            path: pluginCacheDir,
-            cached: cachedVersion,
+            path: firstEntry?.path ?? pluginCacheRoots[0] ?? "",
+            paths: cacheEntries.map((entry) => entry.path),
+            cached: firstEntry?.cached,
             latest: latestVersion,
         };
     }
 
     try {
-        rmSync(pluginCacheDir, { recursive: true, force: true });
+        for (const entry of clearTargets) {
+            rmSync(entry.path, { recursive: true, force: true });
+        }
+        const firstTarget = clearTargets[0];
         return {
             action: "cleared",
-            path: pluginCacheDir,
-            cached: cachedVersion,
+            path: firstTarget?.path ?? pluginCacheRoots[0] ?? "",
+            paths: clearTargets.map((entry) => entry.path),
+            cached: firstTarget?.cached,
             latest: latestVersion,
         };
     } catch (err: unknown) {
         const message = err instanceof Error ? err.message : String(err);
-        return { action: "error", path: pluginCacheDir, error: message };
+        return {
+            action: "error",
+            path: clearTargets[0]?.path ?? existingRoots[0] ?? "",
+            error: message,
+        };
     }
 }

--- a/packages/cli/src/commands/doctor-opencode.test.ts
+++ b/packages/cli/src/commands/doctor-opencode.test.ts
@@ -9,13 +9,13 @@ import {
 import { computeLegacyRustDirIdentity } from "@magic-context/core/features/magic-context/v22-deferred-backfill";
 import { Database } from "@magic-context/core/shared/sqlite";
 import { parse as parseJsonc, stringify as stringifyJsonc } from "comment-json";
-import { runV22BackfillCommands } from "../lib/v22-backfill-commands";
-import { migrateLegacyAgentEnabledConfigForDoctor } from "./doctor-opencode";
 import {
-    clearPluginCache,
     OPENCODE_PLUGIN_ENTRY_WITH_VERSION,
     OPENCODE_PLUGIN_NAME,
-} from "./doctor-opencode-cache";
+} from "../lib/opencode-plugin-cache";
+import { runV22BackfillCommands } from "../lib/v22-backfill-commands";
+import { migrateLegacyAgentEnabledConfigForDoctor } from "./doctor-opencode";
+import { clearPluginCache } from "./doctor-opencode-cache";
 
 function migrate(input: Record<string, unknown>) {
     const logs: Array<{ level: "success" | "warn"; message: string }> = [];
@@ -218,13 +218,31 @@ describe("doctor OpenCode plugin cache", () => {
         expect(existsSync(versionlessCachePath)).toBe(false);
     });
 
-    it("clears existing cache when plugin npm latest is unavailable", async () => {
+    it("preserves existing cache when plugin npm latest is unavailable", async () => {
         const cacheRoot = makeTempDir("mc-opencode-cache-");
         originalXdgCacheHome = process.env.XDG_CACHE_HOME;
         process.env.XDG_CACHE_HOME = cacheRoot;
         const pluginCachePath = createCachedOpenCodePlugin(cacheRoot, "0.29.1");
 
         const result = await clearPluginCache({ latestVersion: null });
+
+        expect(result).toMatchObject({
+            action: "check_unavailable",
+            cached: "0.29.1",
+            path: pluginCachePath,
+            paths: [pluginCachePath],
+        });
+        expect(result.latest).toBeUndefined();
+        expect(existsSync(pluginCachePath)).toBe(true);
+    });
+
+    it("force-clears existing cache even when plugin npm latest is unavailable", async () => {
+        const cacheRoot = makeTempDir("mc-opencode-cache-");
+        originalXdgCacheHome = process.env.XDG_CACHE_HOME;
+        process.env.XDG_CACHE_HOME = cacheRoot;
+        const pluginCachePath = createCachedOpenCodePlugin(cacheRoot, "0.29.1");
+
+        const result = await clearPluginCache({ force: true, latestVersion: null });
 
         expect(result).toMatchObject({
             action: "cleared",

--- a/packages/cli/src/commands/doctor-opencode.test.ts
+++ b/packages/cli/src/commands/doctor-opencode.test.ts
@@ -11,7 +11,11 @@ import { Database } from "@magic-context/core/shared/sqlite";
 import { parse as parseJsonc, stringify as stringifyJsonc } from "comment-json";
 import { runV22BackfillCommands } from "../lib/v22-backfill-commands";
 import { migrateLegacyAgentEnabledConfigForDoctor } from "./doctor-opencode";
-import { clearPluginCache } from "./doctor-opencode-cache";
+import {
+    clearPluginCache,
+    OPENCODE_PLUGIN_ENTRY_WITH_VERSION,
+    OPENCODE_PLUGIN_NAME,
+} from "./doctor-opencode-cache";
 
 function migrate(input: Record<string, unknown>) {
     const logs: Array<{ level: "success" | "warn"; message: string }> = [];
@@ -137,14 +141,12 @@ afterEach(() => {
     }
 });
 
-function createCachedOpenCodePlugin(root: string, version: string): string {
-    const pluginCachePath = join(
-        root,
-        "opencode",
-        "packages",
-        "@cortexkit",
-        "opencode-magic-context@latest",
-    );
+function createCachedOpenCodePlugin(
+    root: string,
+    version: string,
+    entry = OPENCODE_PLUGIN_ENTRY_WITH_VERSION,
+): string {
+    const pluginCachePath = join(root, "opencode", "packages", entry);
     const installedPackagePath = join(
         pluginCachePath,
         "node_modules",
@@ -190,6 +192,48 @@ describe("doctor OpenCode plugin cache", () => {
             path: pluginCachePath,
         });
         expect(existsSync(pluginCachePath)).toBe(true);
+    });
+
+    it("clears stale versionless cache even when @latest cache is current", async () => {
+        const cacheRoot = makeTempDir("mc-opencode-cache-");
+        originalXdgCacheHome = process.env.XDG_CACHE_HOME;
+        process.env.XDG_CACHE_HOME = cacheRoot;
+        const latestCachePath = createCachedOpenCodePlugin(cacheRoot, "0.29.1");
+        const versionlessCachePath = createCachedOpenCodePlugin(
+            cacheRoot,
+            "0.26.0",
+            OPENCODE_PLUGIN_NAME,
+        );
+
+        const result = await clearPluginCache({ latestVersion: "0.29.1" });
+
+        expect(result).toMatchObject({
+            action: "cleared",
+            cached: "0.26.0",
+            latest: "0.29.1",
+            path: versionlessCachePath,
+            paths: [versionlessCachePath],
+        });
+        expect(existsSync(latestCachePath)).toBe(true);
+        expect(existsSync(versionlessCachePath)).toBe(false);
+    });
+
+    it("clears existing cache when plugin npm latest is unavailable", async () => {
+        const cacheRoot = makeTempDir("mc-opencode-cache-");
+        originalXdgCacheHome = process.env.XDG_CACHE_HOME;
+        process.env.XDG_CACHE_HOME = cacheRoot;
+        const pluginCachePath = createCachedOpenCodePlugin(cacheRoot, "0.29.1");
+
+        const result = await clearPluginCache({ latestVersion: null });
+
+        expect(result).toMatchObject({
+            action: "cleared",
+            cached: "0.29.1",
+            path: pluginCachePath,
+            paths: [pluginCachePath],
+        });
+        expect(result.latest).toBeUndefined();
+        expect(existsSync(pluginCachePath)).toBe(false);
     });
 });
 

--- a/packages/cli/src/commands/doctor-opencode.test.ts
+++ b/packages/cli/src/commands/doctor-opencode.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it } from "bun:test";
-import { mkdtempSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import {
     initializeDatabase,
     runMigrations,
@@ -11,6 +11,7 @@ import { Database } from "@magic-context/core/shared/sqlite";
 import { parse as parseJsonc, stringify as stringifyJsonc } from "comment-json";
 import { runV22BackfillCommands } from "../lib/v22-backfill-commands";
 import { migrateLegacyAgentEnabledConfigForDoctor } from "./doctor-opencode";
+import { clearPluginCache } from "./doctor-opencode-cache";
 
 function migrate(input: Record<string, unknown>) {
     const logs: Array<{ level: "success" | "warn"; message: string }> = [];
@@ -71,6 +72,7 @@ describe("doctor OpenCode legacy agent enabled migration", () => {
 
 const tempDirs: string[] = [];
 const dbs: Database[] = [];
+let originalXdgCacheHome: string | undefined;
 
 function makeTempDir(prefix = "mc-v22-doctor-"): string {
     const dir = mkdtempSync(join(tmpdir(), prefix));
@@ -121,12 +123,74 @@ function makeHarness(database: Database, messages: string[]) {
 }
 
 afterEach(() => {
+    if (originalXdgCacheHome === undefined) {
+        delete process.env.XDG_CACHE_HOME;
+    } else {
+        process.env.XDG_CACHE_HOME = originalXdgCacheHome;
+    }
+    originalXdgCacheHome = undefined;
     for (const db of dbs.splice(0)) {
         db.close();
     }
     for (const dir of tempDirs.splice(0)) {
         rmSync(dir, { recursive: true, force: true });
     }
+});
+
+function createCachedOpenCodePlugin(root: string, version: string): string {
+    const pluginCachePath = join(
+        root,
+        "opencode",
+        "packages",
+        "@cortexkit",
+        "opencode-magic-context@latest",
+    );
+    const installedPackagePath = join(
+        pluginCachePath,
+        "node_modules",
+        "@cortexkit",
+        "opencode-magic-context",
+        "package.json",
+    );
+    mkdirSync(dirname(installedPackagePath), { recursive: true });
+    writeFileSync(installedPackagePath, `${JSON.stringify({ version })}\n`);
+    return pluginCachePath;
+}
+
+describe("doctor OpenCode plugin cache", () => {
+    it("clears stale @latest cache when cached plugin is older than npm latest", async () => {
+        const cacheRoot = makeTempDir("mc-opencode-cache-");
+        originalXdgCacheHome = process.env.XDG_CACHE_HOME;
+        process.env.XDG_CACHE_HOME = cacheRoot;
+        const pluginCachePath = createCachedOpenCodePlugin(cacheRoot, "0.26.0");
+
+        const result = await clearPluginCache({ latestVersion: "0.29.1" });
+
+        expect(result).toMatchObject({
+            action: "cleared",
+            cached: "0.26.0",
+            latest: "0.29.1",
+            path: pluginCachePath,
+        });
+        expect(existsSync(pluginCachePath)).toBe(false);
+    });
+
+    it("keeps @latest cache when cached plugin matches npm latest", async () => {
+        const cacheRoot = makeTempDir("mc-opencode-cache-");
+        originalXdgCacheHome = process.env.XDG_CACHE_HOME;
+        process.env.XDG_CACHE_HOME = cacheRoot;
+        const pluginCachePath = createCachedOpenCodePlugin(cacheRoot, "0.29.1");
+
+        const result = await clearPluginCache({ latestVersion: "0.29.1" });
+
+        expect(result).toMatchObject({
+            action: "up_to_date",
+            cached: "0.29.1",
+            latest: "0.29.1",
+            path: pluginCachePath,
+        });
+        expect(existsSync(pluginCachePath)).toBe(true);
+    });
 });
 
 describe("doctor v22 backfill commands", () => {

--- a/packages/cli/src/commands/doctor-opencode.ts
+++ b/packages/cli/src/commands/doctor-opencode.ts
@@ -26,15 +26,15 @@ import { bundleIssueReport } from "../lib/logs-opencode";
 import { migrateDreamerV2ForDoctor } from "../lib/migrate-dreamer-v2-doctor";
 import { migrateExperimentalPinKeyFilesForDoctor } from "../lib/migrate-experimental-doctor";
 import { isOpenCodeInstalled } from "../lib/opencode-helpers";
-import { detectConfigPaths, getMagicContextLogPath } from "../lib/paths";
-import { confirm, intro, log, outro, selectOne, spinner, text } from "../lib/prompts";
-import { runV22BackfillCommands, type V22BackfillCommandArgs } from "../lib/v22-backfill-commands";
 import {
-    clearPluginCache,
     getOpenCodePluginCacheRoots,
     OPENCODE_PLUGIN_ENTRY_WITH_VERSION as PLUGIN_ENTRY_WITH_VERSION,
     OPENCODE_PLUGIN_NAME as PLUGIN_NAME,
-} from "./doctor-opencode-cache";
+} from "../lib/opencode-plugin-cache";
+import { detectConfigPaths, getMagicContextLogPath } from "../lib/paths";
+import { confirm, intro, log, outro, selectOne, spinner, text } from "../lib/prompts";
+import { runV22BackfillCommands, type V22BackfillCommandArgs } from "../lib/v22-backfill-commands";
+import { clearPluginCache } from "./doctor-opencode-cache";
 
 const CLI_PACKAGE_NAME = "@cortexkit/magic-context";
 
@@ -1106,6 +1106,10 @@ export async function runDoctor(
         fixed++;
     } else if (cacheResult.action === "up_to_date") {
         pass(`Plugin cache up to date (v${cacheResult.cached})`);
+    } else if (cacheResult.action === "check_unavailable") {
+        warn(
+            `Plugin cache version check unavailable; preserving cached plugin${cacheResult.cached ? ` (cached: ${cacheResult.cached})` : ""}. Use doctor --force to reinstall it.`,
+        );
     } else if (cacheResult.action === "error") {
         warn(`Could not clear plugin cache: ${cacheResult.error}`);
         log.info(`  Manually delete: ${cacheResult.path}`);

--- a/packages/cli/src/commands/doctor-opencode.ts
+++ b/packages/cli/src/commands/doctor-opencode.ts
@@ -1,5 +1,5 @@
 import { execSync, spawnSync } from "node:child_process";
-import { existsSync, readFileSync, rmSync, statSync } from "node:fs";
+import { existsSync, readFileSync, statSync } from "node:fs";
 import { createRequire } from "node:module";
 import { homedir } from "node:os";
 import { join } from "node:path";
@@ -13,10 +13,7 @@ import {
 import { closeDatabase, openDatabase } from "@magic-context/core/features/magic-context/storage";
 import { detectConflicts } from "@magic-context/core/shared/conflict-detector";
 import { fixConflicts } from "@magic-context/core/shared/conflict-fixer";
-import {
-    getMagicContextStorageDir,
-    getOpenCodeCacheDir,
-} from "@magic-context/core/shared/data-path";
+import { getMagicContextStorageDir } from "@magic-context/core/shared/data-path";
 import { Database } from "@magic-context/core/shared/sqlite";
 import { ensureTuiPluginEntry } from "@magic-context/core/shared/tui-config";
 import { parse, stringify } from "comment-json";
@@ -32,6 +29,7 @@ import { isOpenCodeInstalled } from "../lib/opencode-helpers";
 import { detectConfigPaths, getMagicContextLogPath } from "../lib/paths";
 import { confirm, intro, log, outro, selectOne, spinner, text } from "../lib/prompts";
 import { runV22BackfillCommands, type V22BackfillCommandArgs } from "../lib/v22-backfill-commands";
+import { clearPluginCache, getOpenCodePluginCacheRoots } from "./doctor-opencode-cache";
 
 const PLUGIN_NAME = "@cortexkit/opencode-magic-context";
 const PLUGIN_ENTRY_WITH_VERSION = `${PLUGIN_NAME}@latest`;
@@ -148,78 +146,6 @@ function compareVersions(a: string, b: string): number {
         if (x > y) return 1;
     }
     return 0;
-}
-
-async function clearPluginCache(force = false): Promise<{
-    action: "cleared" | "up_to_date" | "not_found" | "error";
-    path: string;
-    cached?: string;
-    latest?: string;
-    error?: string;
-}> {
-    const cacheDir = getOpenCodeCacheDir();
-    const pluginCacheDir = join(cacheDir, "packages", PLUGIN_ENTRY_WITH_VERSION);
-
-    if (!existsSync(pluginCacheDir)) {
-        return { action: "not_found", path: pluginCacheDir };
-    }
-
-    // Read cached version from the installed package.json (more reliable than package-lock.json)
-    let cachedVersion: string | undefined;
-    try {
-        const installedPkgPath = join(
-            pluginCacheDir,
-            "node_modules",
-            "@cortexkit",
-            "opencode-magic-context",
-            "package.json",
-        );
-        if (existsSync(installedPkgPath)) {
-            const pkg = JSON.parse(readFileSync(installedPkgPath, "utf-8"));
-            if (typeof pkg?.version === "string") {
-                cachedVersion = pkg.version;
-            }
-        }
-    } catch {
-        // Can't read cached version — proceed with clearing
-    }
-
-    // Compare against our own version — when running via `npx @cortexkit/opencode-magic-context@latest doctor`,
-    // our package.json IS the latest published version. No network call needed.
-    // Try multiple relative paths to handle both src/ and dist/ build output locations.
-    const require = createRequire(import.meta.url);
-    let selfVersion: string | undefined;
-    for (const relPath of ["../../package.json", "../package.json"]) {
-        try {
-            selfVersion = (require(relPath) as { version?: string }).version;
-            if (selfVersion) break;
-        } catch {
-            // Try next path
-        }
-    }
-
-    // If we know both versions and they match, skip (unless forced)
-    if (!force && cachedVersion && cachedVersion === selfVersion) {
-        return {
-            action: "up_to_date",
-            path: pluginCacheDir,
-            cached: cachedVersion,
-            latest: selfVersion,
-        };
-    }
-
-    try {
-        rmSync(pluginCacheDir, { recursive: true, force: true });
-        return {
-            action: "cleared",
-            path: pluginCacheDir,
-            cached: cachedVersion,
-            latest: selfVersion,
-        };
-    } catch (err: unknown) {
-        const msg = err instanceof Error ? err.message : String(err);
-        return { action: "error", path: pluginCacheDir, error: msg };
-    }
 }
 
 // ── Issue flow ──────────────────────────────────────────────────────
@@ -370,10 +296,7 @@ async function runIssueFlow(): Promise<number> {
 // no-config / default-provider path (local is the default, so a missing config
 // still means local embeddings).
 function checkLocalEmbeddingRuntimeForDoctor(): { issues: number; localRuntimeBroken?: boolean } {
-    const runtime = checkLocalEmbeddingRuntime([
-        join(getOpenCodeCacheDir(), "packages", PLUGIN_ENTRY_WITH_VERSION),
-        join(getOpenCodeCacheDir(), "packages", PLUGIN_NAME),
-    ]);
+    const runtime = checkLocalEmbeddingRuntime(getOpenCodePluginCacheRoots());
     if (runtime.state === "package-missing" || runtime.state === "binary-missing") {
         log.warn(
             "Embedding provider: local — but the native runtime (onnxruntime-node) " +
@@ -619,7 +542,10 @@ export async function runDoctor(
 
     // 1b. CLI vs npm latest
     const selfVersion = getSelfVersion();
-    const npmLatest = await fetchNpmLatest(CLI_PACKAGE_NAME);
+    const [npmLatest, pluginNpmLatest] = await Promise.all([
+        fetchNpmLatest(CLI_PACKAGE_NAME),
+        fetchNpmLatest(PLUGIN_NAME),
+    ]);
     if (!npmLatest) {
         log.info(`Magic Context CLI v${selfVersion}; npm latest check unavailable`);
     } else if (compareVersions(selfVersion, npmLatest) < 0) {
@@ -1161,7 +1087,10 @@ export async function runDoctor(
     }
 
     // 8. Check plugin npm cache — clear only if outdated
-    const cacheResult = await clearPluginCache(options.force);
+    const cacheResult = await clearPluginCache({
+        force: options.force,
+        latestVersion: pluginNpmLatest ?? npmLatest ?? selfVersion,
+    });
     if (cacheResult.action === "cleared") {
         const versionInfo = cacheResult.cached
             ? ` (cached: ${cacheResult.cached}${cacheResult.latest ? `, latest: ${cacheResult.latest}` : ""})`

--- a/packages/cli/src/commands/doctor-opencode.ts
+++ b/packages/cli/src/commands/doctor-opencode.ts
@@ -29,10 +29,13 @@ import { isOpenCodeInstalled } from "../lib/opencode-helpers";
 import { detectConfigPaths, getMagicContextLogPath } from "../lib/paths";
 import { confirm, intro, log, outro, selectOne, spinner, text } from "../lib/prompts";
 import { runV22BackfillCommands, type V22BackfillCommandArgs } from "../lib/v22-backfill-commands";
-import { clearPluginCache, getOpenCodePluginCacheRoots } from "./doctor-opencode-cache";
+import {
+    clearPluginCache,
+    getOpenCodePluginCacheRoots,
+    OPENCODE_PLUGIN_ENTRY_WITH_VERSION as PLUGIN_ENTRY_WITH_VERSION,
+    OPENCODE_PLUGIN_NAME as PLUGIN_NAME,
+} from "./doctor-opencode-cache";
 
-const PLUGIN_NAME = "@cortexkit/opencode-magic-context";
-const PLUGIN_ENTRY_WITH_VERSION = `${PLUGIN_NAME}@latest`;
 const CLI_PACKAGE_NAME = "@cortexkit/magic-context";
 
 export interface DoctorMigrationLogSink {
@@ -1089,13 +1092,16 @@ export async function runDoctor(
     // 8. Check plugin npm cache — clear only if outdated
     const cacheResult = await clearPluginCache({
         force: options.force,
-        latestVersion: pluginNpmLatest ?? npmLatest ?? selfVersion,
+        latestVersion: pluginNpmLatest,
     });
     if (cacheResult.action === "cleared") {
         const versionInfo = cacheResult.cached
             ? ` (cached: ${cacheResult.cached}${cacheResult.latest ? `, latest: ${cacheResult.latest}` : ""})`
             : "";
-        pass(`Cleared outdated plugin cache${versionInfo} — latest will download on restart`);
+        const reason = cacheResult.latest
+            ? "outdated plugin cache"
+            : "plugin cache (latest version check unavailable)";
+        pass(`Cleared ${reason}${versionInfo} — latest will download on restart`);
         log.info(`  ${cacheResult.path}`);
         fixed++;
     } else if (cacheResult.action === "up_to_date") {

--- a/packages/cli/src/commands/setup-opencode.ts
+++ b/packages/cli/src/commands/setup-opencode.ts
@@ -16,11 +16,13 @@ import {
     getOpenCodeVersion,
     isOpenCodeInstalled,
 } from "../lib/opencode-helpers";
+import {
+    OPENCODE_PLUGIN_ENTRY_WITH_VERSION as PLUGIN_ENTRY,
+    OPENCODE_PLUGIN_NAME as PLUGIN_NAME,
+} from "../lib/opencode-plugin-cache";
 import { detectConfigPaths } from "../lib/paths";
 import { confirm, intro, log, note, outro, promptIO, spinner } from "../lib/prompts";
 
-const PLUGIN_NAME = "@cortexkit/opencode-magic-context";
-const PLUGIN_ENTRY = "@cortexkit/opencode-magic-context@latest";
 const DCP_PLUGIN_NAME = "@tarquinen/opencode-dcp";
 
 // ─── Helpers ──────────────────────────────────────────────

--- a/packages/cli/src/lib/diagnostics-opencode.ts
+++ b/packages/cli/src/lib/diagnostics-opencode.ts
@@ -14,12 +14,15 @@ import { join } from "node:path";
 
 import { parseCompartmentOutput } from "@magic-context/core/hooks/magic-context/compartment-parser";
 import { detectConflicts } from "@magic-context/core/shared/conflict-detector";
-import {
-    getOpenCodeCacheDir,
-    getProjectMagicContextHistorianDir,
-} from "@magic-context/core/shared/data-path";
+import { getProjectMagicContextHistorianDir } from "@magic-context/core/shared/data-path";
 import { parse as parseJsonc } from "comment-json";
 import { getOpenCodeVersion, isOpenCodeInstalled } from "./opencode-helpers";
+import {
+    getOpenCodePluginCacheRoots,
+    getOpenCodePluginPackageJsonPaths,
+    OPENCODE_PLUGIN_ENTRY_WITH_VERSION,
+    OPENCODE_PLUGIN_NAME,
+} from "./opencode-plugin-cache";
 import {
     type ConfigPaths,
     detectConfigPaths,
@@ -27,9 +30,6 @@ import {
     getMagicContextLogPath,
 } from "./paths";
 import { sanitizeConfigValue, sanitizeDiagnosticText, sanitizePathString } from "./redaction";
-
-const PLUGIN_NAME = "@cortexkit/opencode-magic-context";
-const PLUGIN_ENTRY_WITH_VERSION = `${PLUGIN_NAME}@latest`;
 
 export interface DiagnosticReport {
     timestamp: string;
@@ -216,24 +216,20 @@ function getSelfVersion(): string {
 }
 
 function getPluginCacheInfo(): { path: string; cached?: string; latest?: string } {
-    const path = join(getOpenCodeCacheDir(), "packages", PLUGIN_ENTRY_WITH_VERSION);
+    const [path = ""] = getOpenCodePluginCacheRoots();
     let cached: string | undefined;
-    try {
-        const installedPkgPath = join(
-            path,
-            "node_modules",
-            "@cortexkit",
-            "opencode-magic-context",
-            "package.json",
-        );
-        if (existsSync(installedPkgPath)) {
-            const pkg = JSON.parse(readFileSync(installedPkgPath, "utf-8")) as {
-                version?: unknown;
-            };
-            cached = typeof pkg.version === "string" ? pkg.version : undefined;
+    for (const installedPkgPath of getOpenCodePluginPackageJsonPaths()) {
+        try {
+            if (existsSync(installedPkgPath)) {
+                const pkg = JSON.parse(readFileSync(installedPkgPath, "utf-8")) as {
+                    version?: unknown;
+                };
+                cached = typeof pkg.version === "string" ? pkg.version : undefined;
+                if (cached) break;
+            }
+        } catch {
+            cached = undefined;
         }
-    } catch {
-        cached = undefined;
     }
     return { path, cached, latest: getSelfVersion() };
 }
@@ -283,8 +279,9 @@ function configHasPluginEntry(config: Record<string, unknown> | null): boolean {
     const plugins = Array.isArray(config?.plugin) ? config.plugin : [];
     return plugins.some((entry) => {
         if (typeof entry !== "string") return false;
-        if (entry === PLUGIN_NAME) return true;
-        if (entry.startsWith(`${PLUGIN_NAME}@`)) return true;
+        if (entry === OPENCODE_PLUGIN_NAME) return true;
+        if (entry === OPENCODE_PLUGIN_ENTRY_WITH_VERSION) return true;
+        if (entry.startsWith(`${OPENCODE_PLUGIN_NAME}@`)) return true;
         // Local dev paths
         if (entry.includes("opencode-magic-context")) return true;
         return false;

--- a/packages/cli/src/lib/opencode-plugin-cache.ts
+++ b/packages/cli/src/lib/opencode-plugin-cache.ts
@@ -1,0 +1,26 @@
+import { join } from "node:path";
+import { getOpenCodePluginCacheDir } from "./paths";
+
+export const OPENCODE_PLUGIN_NAME = "@cortexkit/opencode-magic-context";
+export const OPENCODE_PLUGIN_ENTRY_WITH_VERSION = `${OPENCODE_PLUGIN_NAME}@latest`;
+
+export function getOpenCodePluginCacheRoots(): string[] {
+    const cacheDir = getOpenCodePluginCacheDir();
+    return [
+        join(cacheDir, OPENCODE_PLUGIN_ENTRY_WITH_VERSION),
+        join(cacheDir, OPENCODE_PLUGIN_NAME),
+    ];
+}
+
+export function getOpenCodePluginPackageJsonPath(pluginCacheRoot: string): string {
+    return join(
+        pluginCacheRoot,
+        "node_modules",
+        ...OPENCODE_PLUGIN_NAME.split("/"),
+        "package.json",
+    );
+}
+
+export function getOpenCodePluginPackageJsonPaths(): string[] {
+    return getOpenCodePluginCacheRoots().map(getOpenCodePluginPackageJsonPath);
+}


### PR DESCRIPTION
## Summary
- compare the cached OpenCode plugin package against the actual npm latest plugin version, not just the CLI package version
- extract OpenCode plugin cache handling into a focused helper module
- add regression coverage for stale @latest cache (0.26.0 cached vs 0.29.1 latest) and matching-cache no-op behavior

## Verification
- bun run test
- bun run typecheck
- bun run lint
- bun run build
- manual QA: ran `bun src/index.ts doctor --harness opencode`; it cleared cached @cortexkit/opencode-magic-context 0.26.0 and opencode restarted with Magic Context 0.29.1

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/magic-context/pr/199"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785211674&installation_id=135454708&pr_number=199&repository=cortexkit%2Fmagic-context&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Fmagic-context%2Fpull%2F199&signature=5c34a50f6793e83f254a4aebff3424be3bcad23041738d6c5833bf5762d6238f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stale OpenCode plugin cache handling in `doctor` by comparing the cached `@cortexkit/opencode-magic-context` to the plugin’s npm latest and safely handling offline cases. Adds shared helpers for plugin cache paths and version files to reduce duplication and improve detection across commands.

- **Bug Fixes**
  - Compares the cached plugin against npm latest and clears only when outdated; also clears versionless cache folders.
  - If the plugin npm latest can’t be fetched, preserves the cache and reports a check-unavailable status; `--force` clears it.
  - Embedding runtime check now uses shared cache roots to avoid false negatives.

- **Refactors**
  - Added `lib/opencode-plugin-cache` with `OPENCODE_PLUGIN_NAME`, `OPENCODE_PLUGIN_ENTRY_WITH_VERSION`, `getOpenCodePluginCacheRoots`, and `getOpenCodePluginPackageJsonPaths`; adopted in `doctor-opencode`, diagnostics, setup, and adapter.
  - Introduced `doctor-opencode-cache.clearPluginCache({ force, latestVersion })`; tests cover stale, matching, versionless, offline, and force-clear paths.

<sup>Written for commit 0b02bc22dca8aed78a9da5c1c9a7e1db275558e5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/magic-context/pull/199?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes the stale OpenCode plugin cache check in `doctor` by fetching the plugin package's own npm latest version (instead of using the CLI package version as a proxy), then clearing the cache only when it is outdated. It also extracts shared cache path helpers and plugin name constants into a new `lib/opencode-plugin-cache.ts` module, and adds a focused `commands/doctor-opencode-cache.ts` helper with full regression coverage.

- **Core fix**: `doctor-opencode.ts` now fetches `pluginNpmLatest` for `@cortexkit/opencode-magic-context` in parallel with the CLI npm check and passes it to `clearPluginCache`; the new `check_unavailable` result action handles the offline case gracefully (preserves cache, warns the user, respects `--force`).
- **Deduplication**: `OPENCODE_PLUGIN_NAME`, `OPENCODE_PLUGIN_ENTRY_WITH_VERSION`, `getOpenCodePluginCacheRoots`, and `getOpenCodePluginPackageJsonPaths` are now defined once and imported everywhere, eliminating four separate local constant definitions.
- **Test coverage**: Five new tests cover stale-cache clearing, current-cache no-op, versionless-cache clearing, offline preservation, and force-clear; `XDG_CACHE_HOME` is correctly saved and restored per test.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge; the bug fix is well-scoped and all affected code paths are covered by new tests.

The change correctly queries the plugin's own npm registry endpoint rather than using the CLI version as a stand-in, and the offline/force/versionless edge cases are all exercised by the new test suite. The only outstanding item is a diagnostic report field that still echoes the CLI version as "latest" for the plugin — an informational inaccuracy that does not affect doctor's decision-making logic.

packages/cli/src/lib/diagnostics-opencode.ts — getPluginCacheInfo still returns getSelfVersion() as the plugin's latest, which can misrepresent the plugin version in bug-report bundles.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/cli/src/lib/opencode-plugin-cache.ts | New shared module exporting plugin name constants and cache path helpers; eliminates duplicate constant definitions across four files. |
| packages/cli/src/commands/doctor-opencode-cache.ts | New helper that encapsulates plugin-cache clearing logic; correctly handles stale, current, versionless, offline, and force-clear paths with a clean result union type. |
| packages/cli/src/commands/doctor-opencode.ts | Core fix: now fetches plugin npm latest in parallel with CLI npm latest and passes it to clearPluginCache; adds handling for the new check_unavailable result action. |
| packages/cli/src/commands/doctor-opencode.test.ts | Adds five focused regression tests covering stale, matching, versionless, offline-preserve, and force-clear scenarios; XDG_CACHE_HOME is correctly saved and restored in afterEach. |
| packages/cli/src/lib/diagnostics-opencode.ts | Adopts shared cache helpers; getPluginCacheInfo still uses getSelfVersion() for the latest field rather than the plugin's actual npm latest, a minor diagnostic inaccuracy. |
| packages/cli/src/adapters/opencode.ts | Replaces inline candidate-list construction with getOpenCodePluginPackageJsonPaths(); removes local duplicate constants. |
| packages/cli/src/commands/setup-opencode.ts | Replaces local PLUGIN_NAME/PLUGIN_ENTRY constants with shared imports; no behavioral change. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant D as doctor-opencode.ts
    participant N as npm registry
    participant C as doctor-opencode-cache.ts
    participant FS as filesystem

    D->>N: "fetchNpmLatest("@cortexkit/magic-context")"
    D->>N: "fetchNpmLatest("@cortexkit/opencode-magic-context")"
    N-->>D: npmLatest (CLI)
    N-->>D: pluginNpmLatest (plugin, or null if offline)

    D->>C: "clearPluginCache({ force, latestVersion: pluginNpmLatest })"
    C->>FS: getOpenCodePluginCacheRoots()
    FS-->>C: existingRoots

    alt no cache found
        C-->>D: "{ action: not_found }"
    else "latestVersion=null and not forced"
        C-->>D: "{ action: check_unavailable }"
    else latestVersion provided
        C->>FS: readCachedPluginVersion(each root)
        FS-->>C: cached versions
        C->>C: "filter cached !== latestVersion"
        alt all entries up to date
            C-->>D: "{ action: up_to_date }"
        else stale or versionless entries
            C->>FS: rmSync(clearTargets)
            C-->>D: "{ action: cleared, paths }"
        end
    else "force=true"
        C->>FS: rmSync(all roots)
        C-->>D: "{ action: cleared }"
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant D as doctor-opencode.ts
    participant N as npm registry
    participant C as doctor-opencode-cache.ts
    participant FS as filesystem

    D->>N: "fetchNpmLatest("@cortexkit/magic-context")"
    D->>N: "fetchNpmLatest("@cortexkit/opencode-magic-context")"
    N-->>D: npmLatest (CLI)
    N-->>D: pluginNpmLatest (plugin, or null if offline)

    D->>C: "clearPluginCache({ force, latestVersion: pluginNpmLatest })"
    C->>FS: getOpenCodePluginCacheRoots()
    FS-->>C: existingRoots

    alt no cache found
        C-->>D: "{ action: not_found }"
    else "latestVersion=null and not forced"
        C-->>D: "{ action: check_unavailable }"
    else latestVersion provided
        C->>FS: readCachedPluginVersion(each root)
        FS-->>C: cached versions
        C->>C: "filter cached !== latestVersion"
        alt all entries up to date
            C-->>D: "{ action: up_to_date }"
        else stale or versionless entries
            C->>FS: rmSync(clearTargets)
            C-->>D: "{ action: cleared, paths }"
        end
    else "force=true"
        C->>FS: rmSync(all roots)
        C-->>D: "{ action: cleared }"
    end
```

</a>
</details>

<sub>Reviews (4): Last reviewed commit: ["Fix offline plugin cache handling"](https://github.com/cortexkit/magic-context/commit/0b02bc22dca8aed78a9da5c1c9a7e1db275558e5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40333990)</sub>

<!-- /greptile_comment -->