### PR TITLE
fix(pi-plugin): retrospective provider SessionManager API mismatch

### DIFF
--- a/packages/pi-plugin/package.json
+++ b/packages/pi-plugin/package.json
@@ -1,71 +1,71 @@
 {
-	"name": "@cortexkit/pi-magic-context",
-	"version": "0.30.1",
-	"type": "module",
-	"description": "Pi coding agent extension for Magic Context — cross-session memory and context management",
-	"main": "dist/index.js",
-	"license": "MIT",
-	"author": "ualtinok",
-	"keywords": [
-		"pi",
-		"pi-coding-agent",
-		"extension",
-		"context",
-		"memory",
-		"magic-context",
-		"ai",
-		"llm"
-	],
-	"repository": {
-		"type": "git",
-		"url": "https://github.com/cortexkit/magic-context",
-		"directory": "packages/pi-plugin"
-	},
-	"files": [
-		"dist",
-		"README.md"
-	],
-	"scripts": {
-		"build": "bun build src/index.ts src/subagent-entry.ts --outdir dist --target node --format esm --external @earendil-works/pi-coding-agent --external @earendil-works/pi-tui --external @huggingface/transformers --external node:sqlite",
-		"typecheck": "tsc --noEmit",
-		"test": "bun test",
-		"lint": "biome check src",
-		"lint:fix": "biome check --write src",
-		"format": "biome format --write src",
-		"format:check": "biome format src",
-		"clean": "rm -rf dist",
-		"prepublishOnly": "bun run build"
-	},
-	"dependencies": {
-		"@huggingface/transformers": "^4.1.0",
-		"@jitl/quickjs-singlefile-cjs-release-asyncify": "0.32.0",
-		"ai-tokenizer": "^1.0.6",
-		"comment-json": "^5.0.0",
-		"quickjs-emscripten": "^0.32.0",
-		"typebox": "^1.3.1",
-		"zod": "^4.1.8"
-	},
-	"devDependencies": {
-		"@biomejs/biome": "^2.5.1",
-		"@earendil-works/pi-coding-agent": "^0.80.2",
-		"@earendil-works/pi-tui": "^0.80.2",
-		"@types/better-sqlite3": "^7.6.13",
-		"@types/bun": "^1.3.10",
-		"@types/node": "^22.20.0",
-		"typescript": "^5.8.0"
-	},
-	"peerDependencies": {
-		"@earendil-works/pi-coding-agent": "^0.80.2",
-		"@earendil-works/pi-tui": "^0.80.2"
-	},
-	"exports": {
-		".": {
-			"import": "./dist/index.js"
-		}
-	},
-	"pi": {
-		"extensions": [
-			"./dist/index.js"
-		]
-	}
+  "name": "@cortexkit/pi-magic-context",
+  "version": "0.30.2",
+  "type": "module",
+  "description": "Pi coding agent extension for Magic Context \u2014 cross-session memory and context management",
+  "main": "dist/index.js",
+  "license": "MIT",
+  "author": "ualtinok",
+  "keywords": [
+    "pi",
+    "pi-coding-agent",
+    "extension",
+    "context",
+    "memory",
+    "magic-context",
+    "ai",
+    "llm"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/cortexkit/magic-context",
+    "directory": "packages/pi-plugin"
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "bun build src/index.ts src/subagent-entry.ts --outdir dist --target node --format esm --external @earendil-works/pi-coding-agent --external @earendil-works/pi-tui --external @huggingface/transformers --external node:sqlite",
+    "typecheck": "tsc --noEmit",
+    "test": "bun test",
+    "lint": "biome check src",
+    "lint:fix": "biome check --write src",
+    "format": "biome format --write src",
+    "format:check": "biome format src",
+    "clean": "rm -rf dist",
+    "prepublishOnly": "bun run build"
+  },
+  "dependencies": {
+    "@huggingface/transformers": "^4.1.0",
+    "@jitl/quickjs-singlefile-cjs-release-asyncify": "0.32.0",
+    "ai-tokenizer": "^1.0.6",
+    "comment-json": "^5.0.0",
+    "quickjs-emscripten": "^0.32.0",
+    "typebox": "^1.3.1",
+    "zod": "^4.1.8"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "^2.5.1",
+    "@earendil-works/pi-coding-agent": "^0.80.2",
+    "@earendil-works/pi-tui": "^0.80.2",
+    "@types/better-sqlite3": "^7.6.13",
+    "@types/bun": "^1.3.10",
+    "@types/node": "^22.20.0",
+    "typescript": "^5.8.0"
+  },
+  "peerDependencies": {
+    "@earendil-works/pi-coding-agent": "^0.80.2",
+    "@earendil-works/pi-tui": "^0.80.2"
+  },
+  "exports": {
+    ".": {
+      "import": "./dist/index.js"
+    }
+  },
+  "pi": {
+    "extensions": [
+      "./dist/index.js"
+    ]
+  }
 }

--- a/packages/pi-plugin/src/dreamer/retrospective-raw-provider-pi.ts
+++ b/packages/pi-plugin/src/dreamer/retrospective-raw-provider-pi.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 
 import type {
@@ -191,20 +192,27 @@ async function loadDefaultPiSessionDeps(): Promise<
 > {
 	const mod = (await import(/* @vite-ignore */ PI_CODING_AGENT_MODULE)) as {
 		SessionManager?: {
-			listSessions?: (sessionDir?: string) => unknown[] | Promise<unknown[]>;
+			listAll?: (sessionDir?: string) => unknown[] | Promise<unknown[]>;
 		};
 		loadEntriesFromFile?: (filePath: string) => unknown[] | Promise<unknown[]>;
+		parseSessionEntries?: (content: string) => unknown[];
 	};
-	const listSessions = mod.SessionManager?.listSessions;
-	const loadEntriesFromFile = mod.loadEntriesFromFile;
-	if (
-		typeof listSessions !== "function" ||
-		typeof loadEntriesFromFile !== "function"
-	) {
+	const listSessions = mod.SessionManager?.listAll;
+	if (typeof listSessions !== "function") {
 		throw new Error(
-			"Pi session APIs unavailable: expected SessionManager.listSessions and loadEntriesFromFile",
+			"Pi session APIs unavailable: expected SessionManager.listAll on pi-coding-agent",
 		);
 	}
+	// loadEntriesFromFile is NOT part of pi-coding-agent's public API —
+	// fall back to readFileSync + parseSessionEntries (both exported).
+	const loadEntriesFromFile: (
+		filePath: string,
+	) => unknown[] | Promise<unknown[]> =
+		mod.loadEntriesFromFile ??
+		((filePath: string) => {
+			const content = readFileSync(filePath, "utf8");
+			return mod.parseSessionEntries?.(content) ?? [];
+		});
 	return {
 		listSessions: listSessions.bind(mod.SessionManager),
 		loadEntriesFromFile,


### PR DESCRIPTION
## Summary

Fix two bugs in `loadDefaultPiSessionDeps()` that prevented the `/ctx-dream retrospective` dream task from discovering Pi sessions, causing it to silently report "Skipped (no work)".

## Bug 1: SessionManager.listSessions doesn't exist

**Symptom:** `loadDefaultPiSessionDeps()` throws `"Pi session APIs unavailable: expected SessionManager.listSessions and loadEntriesFromFile"`

**Root cause:** pi-coding-agent's `SessionManager` class exports `listAll(sessionDir?)`, not `listSessions()`. The code was looking for the wrong method name.

**Fix:** Changed `mod.SessionManager?.listSessions` → `mod.SessionManager?.listAll`

## Bug 2: loadEntriesFromFile not exported

**Symptom:** Even after fixing Bug 1, the function would still throw because `loadEntriesFromFile` is not part of pi-coding-agent's public API.

**Root cause:** `loadEntriesFromFile` exists internally in `session-manager.js` but is not re-exported from the package's `index.js`.

**Fix:** Added a fallback that reads the file with `readFileSync` and parses via the exported `parseSessionEntries()` function.

## Testing

Verified: `/ctx-dream retrospective` now runs successfully on Pi agent.

## Files changed

- `packages/pi-plugin/src/dreamer/retrospective-raw-provider-pi.ts`
- `packages/pi-plugin/package.json` (version bump 0.30.1 → 0.30.2)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/magic-context/pr/201"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785285250&installation_id=135454708&pr_number=201&repository=cortexkit%2Fmagic-context&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Fmagic-context%2Fpull%2F201&signature=b38ed16c52ec949577911ca57f9c03d02ff90737e00b95890e923d9afc806d88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores Pi session discovery in the retrospective provider by aligning with `@earendil-works/pi-coding-agent` APIs. `/ctx-dream retrospective` now runs instead of skipping with “no work”.

- **Bug Fixes**
  - Use `SessionManager.listAll()` instead of the non-existent `listSessions()`.
  - Add fallback for `loadEntriesFromFile`: read file via `readFileSync` and parse with exported `parseSessionEntries()`.

<sup>Written for commit 587ae8e563dc56b2400258f87de3db97f066e128. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/magic-context/pull/201?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This patch fixes two API-mismatch bugs in `loadDefaultPiSessionDeps()` that prevented the retrospective dream task from discovering Pi sessions: the wrong method name (`listSessions` → `listAll`) and a missing public export (`loadEntriesFromFile`), the latter worked around via a `readFileSync` + `parseSessionEntries` fallback.

- **Bug 1 (method name):** `mod.SessionManager?.listSessions` corrected to `mod.SessionManager?.listAll`, matching pi-coding-agent's actual exported API.
- **Bug 2 (missing export):** `loadEntriesFromFile` is no longer checked in the guard; instead a fallback lambda reads the file with `readFileSync` and delegates parsing to `mod.parseSessionEntries`. If `parseSessionEntries` is also absent, the optional chain returns `undefined` and `?? []` silently produces empty entries with no error thrown — the same silent \"Skipped (no work)\" outcome as the original bug.
- **`package.json`:** patch version bump 0.30.1 → 0.30.2; indentation reformatted from tabs to spaces; trailing newline removed.
</details>

<h3>Confidence Score: 3/5</h3>

The listAll rename is correct and low-risk, but the fallback for entry loading introduces a silent no-op path that reproduces the original bug symptom without any diagnostic error.

The listAll rename is straightforward and correct. The parseSessionEntries fallback is more fragile: removing the guard means a future pi-coding-agent API change could silently zero out all session entries without throwing any error, leaving the retrospective task in exactly the Skipped (no work) state it was supposed to escape.

retrospective-raw-provider-pi.ts — specifically the fallback lambda at lines 208-215 and the absence of a guard for parseSessionEntries.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/pi-plugin/src/dreamer/retrospective-raw-provider-pi.ts | Fixes the SessionManager.listSessions → listAll method name and adds a readFileSync+parseSessionEntries fallback for loadEntriesFromFile; the fallback silently returns empty arrays if parseSessionEntries is also absent, reproducing the original "Skipped (no work)" symptom without any diagnostic error. |
| packages/pi-plugin/package.json | Patch version bump 0.30.1 → 0.30.2 and reformatting from tabs to spaces; missing trailing newline at end of file. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(pi-plugin): retrospective provider S..."](https://github.com/cortexkit/magic-context/commit/587ae8e563dc56b2400258f87de3db97f066e128) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40411862)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->