### PR TITLE
docs: add breakdown configuration guide

### DIFF
--- a/docs/breakdown-configuration.md
+++ b/docs/breakdown-configuration.md
@@ -1,0 +1,186 @@
+# Magic Context - Breakdown & Configuration
+
+## Installation
+
+### Proper Install - Global Scope (recommended)
+
+```bash
+opencode plugin @cortexkit/opencode-magic-context --global
+```
+
+This:
+1. Runs `npm install --ignore-scripts` into the opencode cache
+2. Adds the plugin to `opencode.jsonc` `plugin[]` list
+3. Registers server and tui targets
+
+### Package Cache Locations
+
+| Location | Purpose |
+|----------|---------|
+| `~/.cache/opencode/packages/@cortexkit/` | Proper install by `opencode plugin` |
+| `~/.cache/opencode/node_modules/@cortexkit/` | Manual `npm install` (not canonical) |
+| `~/.npm/_npx/` | Cached from npx (not persistent) |
+
+### Backend Data
+
+| Location | Contents |
+|----------|----------|
+| `~/.local/share/cortexkit/magic-context/` | SQLite DB, model limits, ONNX model, RPC sockets |
+| `~/.local/share/opencode/opencode.db` | OpenCode conversation database |
+
+### Verify
+
+```bash
+grep 'magic-context' ~/.config/opencode/opencode.jsonc
+ls ~/.cache/opencode/packages/@cortexkit/opencode-magic-context@latest/
+ls ~/.local/share/cortexkit/magic-context/
+```
+
+---
+
+## Plugin Schema
+
+### opencode.jsonc Entry
+
+```jsonc
+{
+  "plugin": [
+    "@cortexkit/opencode-magic-context"
+  ]
+}
+```
+
+No `@latest` tag - `opencode plugin` resolves and strips it on install.
+
+### Agent Model Binding
+
+All agents reference `"model": "opencode/big-pickle"` (160K context).
+
+Available `opencode/` model IDs:
+- `big-pickle` - 160,000 context
+- `deepseek-v4-flash` - 1,000,000 context
+- `deepseek-v4-flash-free` - 200,000 context
+- `deepseek-v4-pro` - 1,000,000 context
+- `claude-sonnet-4` - 1,000,000 context
+- `claude-opus-4-7` - 1,000,000 context
+- `gpt-5.4` - 922,000 context
+- `gemini-3.5-flash` - 1,048,576 context
+
+### Compaction Settings
+
+```jsonc
+{
+  "compaction": {
+    "auto": false,
+    "prune": false,
+    "reserved": 20000
+  }
+}
+```
+
+When Magic Context is active, compaction is managed by the plugin, not OpenCode's native engine.
+
+---
+
+## Backend Architecture
+
+### Data Directory: `~/.local/share/cortexkit/magic-context/` (~96 MB)
+
+| File | Purpose |
+|------|---------|
+| `context.db` (+SHM, +WAL) | SQLite - session state, compacted history |
+| `model-context-limits-opencode.json` | Per-model context limits (2,400+ entries) |
+| `models/Xenova/all-MiniLM-L6-v2/` | ONNX embedding model |
+| `rpc/` | RPC communication ports |
+| `last_announced_version` | Version announcement tracker |
+
+### Model Context Limits
+
+The `model-context-limits-opencode.json` caches context window limits populated from OpenCode's `config.providers()` SDK endpoint. Magic Context reads the live resolved config (never reads `models.json` directly) to avoid torn-read issues.
+
+```jsonc
+{
+  "opencode/big-pickle": 160000,
+  "opencode/deepseek-v4-flash": 1000000,
+  // ... 2400+ entries
+}
+```
+
+### Context Resolution Flow
+
+```
+Plugin startup -> warm apiCache from last-known-good file
+OpenCode SDK -> config.providers() -> merged models
+  (live + compiled-in + auth-plugin caps)
+Magic Context -> consumes merged result
+Result bounded to [20k, 3M] range
+```
+
+### Process Architecture
+
+```
+OpenCode (main process)
+  +-- MCP servers (git, mempalace, hf-mcp, etc.)
+  +-- Magic Context (child process)
+        +-- SQLite (context.db)
+        +-- ONNX model (all-MiniLM-L6-v2)
+        +-- RPC socket
+```
+
+---
+
+## Troubleshooting
+
+### "Model not found: opencode/small-pickle. Did you mean: big-pickle?"
+
+**Cause:** OpenCode's runtime tries to resolve `opencode/small-pickle` which doesn't exist in the model catalog. Appears during context compaction cycles.
+
+**Solution:** Harmless - no functional impact. `big-pickle` (160K context) is the correct model already configured for all agents. This is an upstream model alias issue - cannot fix via config. Ignore or report to OpenCode.
+
+### Duplicate Plugin Entries
+
+**Solution:** Check both config files:
+
+```bash
+grep 'magic-context' ~/.config/opencode/opencode.jsonc
+cat ~/.opencode/opencode.json  # delete if global scope used
+cat ~/.opencode/tui.json       # delete if global scope used
+```
+
+Keep plugin in only one scope.
+
+### Package Missing (Plugin Registered But Not Installed)
+
+**Symptom:** Plugin listed in config but OpenCode shows loading errors.
+
+**Solution:** Install manually to cache:
+
+```bash
+cd ~/.cache/opencode && npm install @cortexkit/opencode-magic-context --ignore-scripts
+```
+
+Or re-install with `opencode plugin @cortexkit/opencode-magic-context --global`.
+
+---
+
+## FAQ
+
+### Q: Why does Magic Context use its own SQLite database?
+
+The plugin needs persistent session state for context management that survives OpenCode restarts. It cannot rely on OpenCode's in-memory state. The database at `context.db` stores compacted history, configuration overrides, and session bookkeeping.
+
+### Q: Where does the ONNX model come from?
+
+`all-MiniLM-L6-v2` is a sentence-transformer embedding model downloaded from Hugging Face (Xenova/onnx conversion). It's used by Magic Context's sidebar for semantic compression features.
+
+### Q: Does Magic Context read `~/.cache/opencode/models.json`?
+
+No. Magic Context explicitly does NOT read `models.json` due to torn-read issues. It consumes the merged, live-resolved model config from OpenCode's `config.providers()` API endpoint, which already combines the live cache, compiled-in snapshot, opencode.json overrides, and auth-plugin caps.
+
+### Q: What happens if both local and global scope have the plugin?
+
+OpenCode loads both entries, potentially causing duplicate initialization. Remove one scope (preferably the local `~/.opencode/` files) to keep only the global scope.
+
+### Q: Is the opencode/small-pickle error breaking anything?
+
+No. It's a console warning during compaction with zero functional impact. The model routing still works correctly with the configured `opencode/big-pickle`.

--- a/docs/breakdown-configuration.md
+++ b/docs/breakdown-configuration.md
@@ -156,7 +156,7 @@ cat ~/.opencode/tui.json 2>/dev/null
 # never deletes the entire file even if it contains other config.
 if [ -f ~/.opencode/opencode.json ]; then
   # Always filter first, then del only if nothing remains.
-jq '(.plugin |= map(select(. != "@cortexkit/opencode-magic-context"))) | if (.plugin | length) == 0 then del(.plugin) else . end' \\
+jq '(.plugin |= map(select(. != "@cortexkit/opencode-magic-context"))) | if (.plugin | length) == 0 then del(.plugin) else . end' \
   ~/.opencode/opencode.json > /tmp/opencode_tmp.json && mv /tmp/opencode_tmp.json ~/.opencode/opencode.json
   echo "Removed magic-context entry from plugin array"
 fi

--- a/docs/breakdown-configuration.md
+++ b/docs/breakdown-configuration.md
@@ -149,13 +149,14 @@ cat ~/.opencode/opencode.json 2>/dev/null
 cat ~/.opencode/tui.json 2>/dev/null
 ```
 
-**To remove only the plugin entry (not the whole file)** — if the local files contain other settings beyond the plugin entry, edit the file and remove just `"@cortexkit/opencode-magic-context"` from the `"plugin"` array. If the file contains only the plugin entry or no other useful config, delete the entire file:
+**To remove only the plugin entry (not the whole file):**
 
 ```bash
-# Safe deletion check — only if file consists solely of the plugin entry:
-if [ -f ~/.opencode/opencode.json ] && [ "$(jq '.plugin | length' ~/.opencode/opencode.json 2>/dev/null)" = "1" ]; then
-  rm ~/.opencode/opencode.json
-  echo "Removed (only plugin entry)"
+# Targeted removal — removes just the magic-context entry from the plugin array,
+# never deletes the entire file even if it contains other config.
+if [ -f ~/.opencode/opencode.json ]; then
+  jq 'if (.plugin | length) == 1 then del(.plugin) else (.plugin |= map(select(. != "@cortexkit/opencode-magic-context"))) end'     ~/.opencode/opencode.json > /tmp/opencode_tmp.json && mv /tmp/opencode_tmp.json ~/.opencode/opencode.json
+  echo "Removed magic-context entry from plugin array"
 fi
 ```
 

--- a/docs/breakdown-configuration.md
+++ b/docs/breakdown-configuration.md
@@ -155,7 +155,9 @@ cat ~/.opencode/tui.json 2>/dev/null
 # Targeted removal — removes just the magic-context entry from the plugin array,
 # never deletes the entire file even if it contains other config.
 if [ -f ~/.opencode/opencode.json ]; then
-  jq 'if (.plugin | length) == 1 then del(.plugin) else (.plugin |= map(select(. != "@cortexkit/opencode-magic-context"))) end'     ~/.opencode/opencode.json > /tmp/opencode_tmp.json && mv /tmp/opencode_tmp.json ~/.opencode/opencode.json
+  # Always filter first, then del only if nothing remains.
+jq '(.plugin |= map(select(. != "@cortexkit/opencode-magic-context"))) | if (.plugin | length) == 0 then del(.plugin) else . end' \\
+  ~/.opencode/opencode.json > /tmp/opencode_tmp.json && mv /tmp/opencode_tmp.json ~/.opencode/opencode.json
   echo "Removed magic-context entry from plugin array"
 fi
 ```
@@ -166,13 +168,13 @@ Keep plugin in only one scope.
 
 **Symptom:** Plugin listed in config but OpenCode shows loading errors.
 
-**Solution:** Install manually to cache:
+**Solution:** Re-install with the proper command:
 
 ```bash
-cd ~/.cache/opencode && npm install @cortexkit/opencode-magic-context --ignore-scripts
+opencode plugin @cortexkit/opencode-magic-context --global
 ```
 
-Or re-install with `opencode plugin @cortexkit/opencode-magic-context --global`.
+This installs to the canonical cache path (`~/.cache/opencode/packages/@cortexkit/`). Only use manual `npm install` inside `~/.cache/opencode` as a last resort — it installs to `node_modules/` which the package cache table above notes is **not canonical** and may not be discovered by OpenCode.
 
 ---
 

--- a/docs/breakdown-configuration.md
+++ b/docs/breakdown-configuration.md
@@ -157,8 +157,7 @@ cat ~/.opencode/tui.json 2>/dev/null
 if [ -f ~/.opencode/opencode.json ]; then
   # Always filter first, then del only if nothing remains.
 jq '(.plugin |= map(select(. != "@cortexkit/opencode-magic-context"))) | if (.plugin | length) == 0 then del(.plugin) else . end' \
-  ~/.opencode/opencode.json > /tmp/opencode_tmp.json && mv /tmp/opencode_tmp.json ~/.opencode/opencode.json
-  echo "Removed magic-context entry from plugin array" && :
+  ~/.opencode/opencode.json > /tmp/opencode_tmp.json && mv /tmp/opencode_tmp.json ~/.opencode/opencode.json && echo "Removed magic-context entry from plugin array" && :
 fi
 ```
 

--- a/docs/breakdown-configuration.md
+++ b/docs/breakdown-configuration.md
@@ -158,7 +158,7 @@ if [ -f ~/.opencode/opencode.json ]; then
   # Always filter first, then del only if nothing remains.
 jq '(.plugin |= map(select(. != "@cortexkit/opencode-magic-context"))) | if (.plugin | length) == 0 then del(.plugin) else . end' \
   ~/.opencode/opencode.json > /tmp/opencode_tmp.json && mv /tmp/opencode_tmp.json ~/.opencode/opencode.json
-  echo "Removed magic-context entry from plugin array"
+  echo "Removed magic-context entry from plugin array" && :
 fi
 ```
 

--- a/docs/breakdown-configuration.md
+++ b/docs/breakdown-configuration.md
@@ -32,7 +32,7 @@ This:
 
 ```bash
 grep 'magic-context' ~/.config/opencode/opencode.jsonc
-ls ~/.cache/opencode/packages/@cortexkit/opencode-magic-context@latest/
+ls ~/.cache/opencode/packages/@cortexkit/
 ls ~/.local/share/cortexkit/magic-context/
 ```
 
@@ -143,8 +143,20 @@ OpenCode (main process)
 
 ```bash
 grep 'magic-context' ~/.config/opencode/opencode.jsonc
-cat ~/.opencode/opencode.json  # delete if global scope used
-cat ~/.opencode/tui.json       # delete if global scope used
+
+# Check if local scope files exist and what's in them:
+cat ~/.opencode/opencode.json 2>/dev/null
+cat ~/.opencode/tui.json 2>/dev/null
+```
+
+**To remove only the plugin entry (not the whole file)** — if the local files contain other settings beyond the plugin entry, edit the file and remove just `"@cortexkit/opencode-magic-context"` from the `"plugin"` array. If the file contains only the plugin entry or no other useful config, delete the entire file:
+
+```bash
+# Safe deletion check — only if file consists solely of the plugin entry:
+if [ -f ~/.opencode/opencode.json ] && [ "$(jq '.plugin | length' ~/.opencode/opencode.json 2>/dev/null)" = "1" ]; then
+  rm ~/.opencode/opencode.json
+  echo "Removed (only plugin entry)"
+fi
 ```
 
 Keep plugin in only one scope.


### PR DESCRIPTION
Breakdown and configuration reference for Magic Context plugin installation, plugin schema, backend architecture, troubleshooting, and FAQ.

Covers:
- Global vs local scope installation, cache locations
- Plugin schema (opencode.jsonc entry, model binding, compaction)
- Backend architecture (SQLite, ONNX model, RPC, context resolution)
- Troubleshooting (small-pickle error, duplicate entries, missing package)
- FAQ (5 common questions)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/magic-context/pr/205"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785405399&installation_id=135454708&pr_number=205&repository=cortexkit%2Fmagic-context&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Fmagic-context%2Fpull%2F205&signature=543a8770d8e80f92b3a94e355cb197ac86fd6a374b767aaea0949f225d1616d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a breakdown and configuration guide for the Magic Context plugin to simplify install, setup, and troubleshooting. Clarifies canonical install paths and makes the duplicate-entry cleanup script safe and accurate.

- **Bug Fixes**
  - Verify step now checks `~/.cache/opencode/packages/@cortexkit/` (no `@latest`) to match `opencode plugin` installs.
  - Cleanup script: filters out `@cortexkit/opencode-magic-context`, deletes the `plugin` key only if empty, fixes bash line continuation (single `\`), and chains the success echo with `&&` after `mv` (removed trailing `&& :`) so it only prints on success.
  - “Package Missing” guidance now uses `opencode plugin @cortexkit/opencode-magic-context --global` and warns against manual `npm install` to non-canonical `~/.cache/opencode/node_modules/`.

<sup>Written for commit cc54df170c50d0dab37e43c97446970d745ff287. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/magic-context/pull/205?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds `docs/breakdown-configuration.md`, a new reference guide for the Magic Context plugin covering installation, plugin schema, backend architecture, troubleshooting, and FAQ. It also resolves all four issues flagged in the previous review round (wholesale file deletion, `@latest` verify path, jq filter-then-check logic, and unconditional echo).

- **Installation & verify**: Documents global vs local scope, canonical cache paths (`~/.cache/opencode/packages/`), and corrects the verify snippet to list the `@cortexkit/` directory without an `@latest` suffix.
- **Duplicate-entry cleanup**: Replaces the destructive whole-file delete with a surgical `jq` pipeline that filters only the `@cortexkit/opencode-magic-context` entry, deletes the `plugin` key only when the filtered result is empty, and chains `echo` with `&&` so it prints only on success.
- **Backend & FAQ**: Explains SQLite session state, ONNX model origin, `config.providers()` vs `models.json`, and the `opencode/small-pickle` console warning.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — adds a documentation-only file with no runtime code changes; all previously flagged correctness issues in the bash cleanup snippet have been resolved.

The only changed file is a new markdown guide. The previous round's concerns (file clobbering, wrong @latest path, incorrect jq length condition, unconditional echo) are all addressed in this revision. The two remaining notes are minor robustness suggestions in a copy-paste troubleshooting snippet and do not affect any runtime behavior.

No files require special attention — the cleanup snippet in the Duplicate Plugin Entries section has two small hardening opportunities flagged as suggestions.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/breakdown-configuration.md | New documentation guide covering install paths, plugin schema, backend architecture, troubleshooting, and FAQ; addresses all previously flagged issues (file clobbering, @latest verify path, jq filter logic, echo chaining). Two minor style/robustness P2 notes remain in the cleanup snippet. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant OC as OpenCode (main)
    participant MC as Magic Context (child)
    participant SDK as config.providers() SDK
    participant DB as SQLite (context.db)
    participant ONNX as ONNX Model

    OC->>MC: spawn child process
    MC->>DB: open context.db (SQLite)
    MC->>MC: warm apiCache from last-known-good file
    MC->>SDK: config.providers()
    SDK-->>MC: merged models (live + compiled-in + auth caps)
    MC->>MC: bound result to [20k, 3M] range
    MC->>ONNX: load all-MiniLM-L6-v2
    MC-->>OC: RPC socket ready
    OC->>MC: context compaction request
    MC->>DB: read/write compacted history
    MC-->>OC: resolved context window
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant OC as OpenCode (main)
    participant MC as Magic Context (child)
    participant SDK as config.providers() SDK
    participant DB as SQLite (context.db)
    participant ONNX as ONNX Model

    OC->>MC: spawn child process
    MC->>DB: open context.db (SQLite)
    MC->>MC: warm apiCache from last-known-good file
    MC->>SDK: config.providers()
    SDK-->>MC: merged models (live + compiled-in + auth caps)
    MC->>MC: bound result to [20k, 3M] range
    MC->>ONNX: load all-MiniLM-L6-v2
    MC-->>OC: RPC socket ready
    OC->>MC: context compaction request
    MC->>DB: read/write compacted history
    MC-->>OC: resolved context window
```

</a>
</details>

<sub>Reviews (6): Last reviewed commit: ["Fix: proper &amp;&amp; chain for echo (remove st..."](https://github.com/cortexkit/magic-context/commit/cc54df170c50d0dab37e43c97446970d745ff287) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40773277)</sub>

<!-- /greptile_comment -->