### PR TITLE
fix(cli): doctor check uses v2 task schedule instead of removed v1 user_memories key

### DIFF
--- a/packages/cli/src/commands/doctor-opencode.test.ts
+++ b/packages/cli/src/commands/doctor-opencode.test.ts
@@ -15,6 +15,7 @@ import {
 } from "../lib/opencode-plugin-cache";
 import { runV22BackfillCommands } from "../lib/v22-backfill-commands";
 import {
+    checkUserMemoriesDreamerCompatibility,
     collectNpmReleaseAgeWarnings,
     getUserNpmrcPath,
     isPinnedOpenCodePluginSpecifier,
@@ -76,6 +77,79 @@ describe("doctor OpenCode legacy agent enabled migration", () => {
 
         expect(serialized).toContain('"disable": true');
         expect(serialized).not.toContain('"enabled"');
+    });
+});
+
+describe("checkUserMemoriesDreamerCompatibility", () => {
+    const WARNING =
+        'dreamer.tasks["review-user-memories"] is scheduled but dreamer.disable=true, so new promotions will not run. Remove dreamer.disable or set dreamer.tasks["review-user-memories"].schedule="" to disable the task.';
+
+    it("warns when review-user-memories is scheduled and dreamer.disable=true", () => {
+        const result = checkUserMemoriesDreamerCompatibility({
+            dreamer: {
+                disable: true,
+                tasks: { "review-user-memories": { schedule: "0 2 * * *" } },
+            },
+        });
+        expect(result).toBe(WARNING);
+    });
+
+    it("returns null when dreamer is not disabled", () => {
+        const result = checkUserMemoriesDreamerCompatibility({
+            dreamer: {
+                disable: false,
+                tasks: { "review-user-memories": { schedule: "0 2 * * *" } },
+            },
+        });
+        expect(result).toBeNull();
+    });
+
+    it("returns null when review-user-memories schedule is empty", () => {
+        const result = checkUserMemoriesDreamerCompatibility({
+            dreamer: {
+                disable: true,
+                tasks: { "review-user-memories": { schedule: "" } },
+            },
+        });
+        expect(result).toBeNull();
+    });
+
+    it("returns null when review-user-memories schedule is whitespace-only", () => {
+        const result = checkUserMemoriesDreamerCompatibility({
+            dreamer: {
+                disable: true,
+                tasks: { "review-user-memories": { schedule: "   " } },
+            },
+        });
+        expect(result).toBeNull();
+    });
+
+    it("returns null when review-user-memories task is absent", () => {
+        const result = checkUserMemoriesDreamerCompatibility({
+            dreamer: { disable: true, tasks: { verify: { schedule: "0 2 * * *" } } },
+        });
+        expect(result).toBeNull();
+    });
+
+    it("returns null when dreamer block is absent", () => {
+        expect(checkUserMemoriesDreamerCompatibility({})).toBeNull();
+    });
+
+    it("returns null when tasks block is absent (legacy v1 shape without user_memories)", () => {
+        const result = checkUserMemoriesDreamerCompatibility({
+            dreamer: { disable: true },
+        });
+        expect(result).toBeNull();
+    });
+
+    it("does not read legacy dreamer.user_memories (v1 key, migrated away in v2)", () => {
+        const result = checkUserMemoriesDreamerCompatibility({
+            dreamer: {
+                disable: true,
+                user_memories: { enabled: true },
+            },
+        });
+        expect(result).toBeNull();
     });
 });
 

--- a/packages/cli/src/commands/doctor-opencode.ts
+++ b/packages/cli/src/commands/doctor-opencode.ts
@@ -108,6 +108,25 @@ export function migrateLegacyAgentEnabledConfigForDoctor(
 }
 
 /**
+ * Check whether the `review-user-memories` dreamer task is scheduled while the
+ * dreamer itself is disabled, a no-op combination where candidate promotions
+ * will never run. In v2, user-memory collection is gated by the task schedule
+ * (non-empty = enabled), replacing the v1 `dreamer.user_memories` block.
+ * Returns the warning message when the combination is wrong, or null otherwise.
+ */
+export function checkUserMemoriesDreamerCompatibility(
+    mcConfig: Record<string, unknown>,
+): string | null {
+    const dreamerObj = mcConfig?.dreamer as Record<string, unknown> | undefined;
+    if (dreamerObj?.disable !== true) return null;
+    const tasksObj = dreamerObj.tasks as Record<string, unknown> | undefined;
+    const reviewTask = tasksObj?.["review-user-memories"] as Record<string, unknown> | undefined;
+    const schedule = reviewTask?.schedule;
+    if (typeof schedule !== "string" || schedule.trim() === "") return null;
+    return 'dreamer.tasks["review-user-memories"] is scheduled but dreamer.disable=true, so new promotions will not run. Remove dreamer.disable or set dreamer.tasks["review-user-memories"].schedule="" to disable the task.';
+}
+
+/**
  * Fetch the latest version of an npm package from the registry. Returns null
  * on any error so the doctor can report "check unavailable" rather than fail.
  */
@@ -1042,23 +1061,17 @@ export async function runDoctor(
     }
 
     // 7. Check user memories + dreamer compatibility.
-    // user_memories graduated from experimental to dreamer.user_memories in
-    // v0.14, and the default is now enabled. Candidate extraction still
-    // requires dreamer to actually promote candidates into stable memories,
+    // In v2, user-memory collection is gated by the `review-user-memories` task
+    // schedule (non-empty = enabled), replacing the v1 `dreamer.user_memories`
+    // block. The task needs the dreamer to actually run to promote candidates,
     // so warn loudly when the combination is wrong.
     if (existsSync(paths.magicContextConfig)) {
         try {
             const mcRaw = readFileSync(paths.magicContextConfig, "utf-8");
             const mcConfig = parse(mcRaw) as Record<string, unknown>;
-            const dreamerObj = mcConfig?.dreamer as Record<string, unknown> | undefined;
-            const dreamerDisabled = dreamerObj?.disable === true;
-            const userMemObj = dreamerObj?.user_memories as Record<string, unknown> | undefined;
-            // user_memories defaults to enabled, so treat `undefined` as true.
-            const userMemEnabled = userMemObj?.enabled !== false;
-            if (userMemEnabled && dreamerDisabled) {
-                log.warn(
-                    "dreamer.user_memories is enabled but dreamer.disable=true, so new promotions will not run. Remove dreamer.disable or set dreamer.user_memories.enabled=false.",
-                );
+            const warning = checkUserMemoriesDreamerCompatibility(mcConfig);
+            if (warning) {
+                log.warn(warning);
                 issues++;
             }
         } catch {


### PR DESCRIPTION
Fixes #220.

### Problem

The doctor check (section 7) read `dreamer.user_memories.enabled`, a v1 config key
that was migrated to `dreamer.tasks["review-user-memories"].schedule` in v2. After
migrateDreamerV2ForDoctor runs and writes back, the key is gone from the file. The
default-true logic (`undefined !== false`) always fired the warning when
`dreamer.disable=true`, and the message told users to set a non-existent setting.

### Fix

- Extracted check into `checkUserMemoriesDreamerCompatibility()`
- Reads `dreamer.tasks["review-user-memories"].schedule` (matches runtime gate in task-config.ts)
- Updated warning message to reference v2 setting
- Added 8 unit tests

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/magic-context/pr/219"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786060691&installation_id=135454708&pr_number=219&repository=cortexkit%2Fmagic-context&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Fmagic-context%2Fpull%2F219&signature=b9d3317d98d014d17d2eb60335bc2b25cc8681fbcafc423eab80d1c93e16448e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the doctor CLI check to use the v2 task schedule instead of the removed v1 `user_memories` key, preventing false warnings when `dreamer.disable=true`. The warning now points to the correct v2 setting and matches runtime gating.

- Bug Fixes
  - Read `dreamer.tasks["review-user-memories"].schedule` and ignore legacy `dreamer.user_memories`.
  - Updated warning to reference v2 config and explain the no-op combo with `dreamer.disable=true`.
  - Extracted `checkUserMemoriesDreamerCompatibility()` and added 8 unit tests.

<sup>Written for commit 7c0c3ee88782020b2ab39c54f000075b6816e0c3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/magic-context/pull/219?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR updates the OpenCode doctor check for the v2 dreamer task config.

- Adds a helper for `review-user-memories` and `dreamer.disable` compatibility.
- Reads `dreamer.tasks["review-user-memories"].schedule` instead of the old v1 key.
- Updates the warning message to point at the v2 setting.
- Adds unit tests for scheduled, disabled, empty, absent, and legacy-key cases.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.
- The new check matches the v2 runtime behavior for empty or missing task schedules.
- The added export is additive and the test file already imports this module.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/cli/src/commands/doctor-opencode.ts | Adds the v2 schedule-based compatibility helper and uses it from the doctor warning path. |
| packages/cli/src/commands/doctor-opencode.test.ts | Adds focused coverage for the new compatibility helper and the legacy key behavior. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(cli): doctor check uses v2 task sche..."](https://github.com/cortexkit/magic-context/commit/7c0c3ee88782020b2ab39c54f000075b6816e0c3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42568443)</sub>

<!-- /greptile_comment -->