### PR TITLE
fix(cli): execute OpenCode command shims on Windows

### DIFF
--- a/packages/cli/src/lib/opencode-helpers.test.ts
+++ b/packages/cli/src/lib/opencode-helpers.test.ts
@@ -6,6 +6,7 @@ import { detectOpenCodeInstallations } from "./opencode-detect";
 import {
     describeOpenCodeInstallations,
     getAvailableModels,
+    getOpenCodeCommandInvocation,
     getOpenCodeVersion,
     OPENCODE_VERSION_PROBE_TIMEOUT_MS,
 } from "./opencode-helpers";
@@ -14,9 +15,15 @@ import {
 // #196 follow-up: a stock CLI not on PATH must still enumerate). POSIX-only:
 // the test writes an executable shell stub, which CI runs on Linux/macOS.
 const isPosix = process.platform !== "win32";
+const originalComSpec = process.env.ComSpec;
+const originalPathExpansionProbe = process.env.MC_OPENCODE_TEST_PATH;
 const tempDirs: string[] = [];
 
 afterEach(() => {
+    if (originalComSpec === undefined) delete process.env.ComSpec;
+    else process.env.ComSpec = originalComSpec;
+    if (originalPathExpansionProbe === undefined) delete process.env.MC_OPENCODE_TEST_PATH;
+    else process.env.MC_OPENCODE_TEST_PATH = originalPathExpansionProbe;
     for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
 });
 
@@ -38,6 +45,86 @@ function fakeHomeOpencode(body: string): { home: string; bin: string } {
     chmodSync(bin, 0o755);
     return { home, bin };
 }
+
+function fakeOpenCodeCommandShim(): string {
+    const dir = mkdtempSync(join(tmpdir(), "mc %MC_OPENCODE_TEST_PATH% & shim "));
+    tempDirs.push(dir);
+    const shim = join(dir, "opencode.cmd");
+
+    if (process.platform === "win32") {
+        writeFileSync(
+            shim,
+            [
+                "@echo off",
+                'if "%~1"=="--version" (',
+                "  echo 1.18.7",
+                ') else if "%~1"=="models" (',
+                "  echo anthropic/claude-opus-4-8",
+                "  echo openai/gpt-5.5",
+                ")",
+            ].join("\r\n"),
+        );
+    } else {
+        const comSpec = join(dir, "fake-cmd");
+        writeFileSync(
+            comSpec,
+            '#!/bin/sh\ncase "$5" in\n  *--version*) echo "1.18.7" ;;\n  *models*) printf "anthropic/claude-opus-4-8\\nopenai/gpt-5.5\\n" ;;\nesac\n',
+        );
+        chmodSync(comSpec, 0o755);
+        process.env.ComSpec = comSpec;
+    }
+
+    return shim;
+}
+
+describe("OpenCode command execution", () => {
+    it("routes cmd and bat shims through ComSpec", () => {
+        process.env.ComSpec = "custom-cmd.exe";
+
+        expect(getOpenCodeCommandInvocation("C:\\npm\\opencode.CMD", ["--version"])).toEqual({
+            command: "custom-cmd.exe",
+            args: [
+                "/d",
+                "/s",
+                "/v:off",
+                "/c",
+                '""%MAGIC_CONTEXT_OPENCODE_BINARY%" "--version""',
+            ],
+            env: { MAGIC_CONTEXT_OPENCODE_BINARY: "C:\\npm\\opencode.CMD" },
+            windowsVerbatimArguments: true,
+        });
+        expect(getOpenCodeCommandInvocation("C:\\npm\\opencode.bat", ["models"])).toEqual({
+            command: "custom-cmd.exe",
+            args: [
+                "/d",
+                "/s",
+                "/v:off",
+                "/c",
+                '""%MAGIC_CONTEXT_OPENCODE_BINARY%" "models""',
+            ],
+            env: { MAGIC_CONTEXT_OPENCODE_BINARY: "C:\\npm\\opencode.bat" },
+            windowsVerbatimArguments: true,
+        });
+    });
+
+    it("invokes native executables directly", () => {
+        expect(getOpenCodeCommandInvocation("/usr/local/bin/opencode", ["--version"])).toEqual({
+            command: "/usr/local/bin/opencode",
+            args: ["--version"],
+        });
+    });
+
+    it("executes a cmd shim for version and model probes", () => {
+        process.env.MC_OPENCODE_TEST_PATH = "expanded-to-the-wrong-path";
+        const shim = fakeOpenCodeCommandShim();
+
+        expect(getOpenCodeVersion(shim)).toBe("1.18.7");
+        expect(getAvailableModels(shim)).toEqual([
+            "anthropic/claude-opus-4-8",
+            "openai/gpt-5.5",
+        ]);
+    });
+});
 
 describe.if(isPosix)("opencode helpers with a resolved binary path", () => {
     it("getAvailableModels invokes the given absolute binary", () => {

--- a/packages/cli/src/lib/opencode-helpers.ts
+++ b/packages/cli/src/lib/opencode-helpers.ts
@@ -1,17 +1,59 @@
 import { execFileSync, execSync } from "node:child_process";
+import { extname } from "node:path";
 import type { OpenCodeInstallation } from "./opencode-detect";
+
+export interface OpenCodeCommandInvocation {
+    command: string;
+    args: string[];
+    env?: Record<string, string>;
+    windowsVerbatimArguments?: true;
+}
+
+const OPENCODE_BINARY_ENV = "MAGIC_CONTEXT_OPENCODE_BINARY";
+
+export function getOpenCodeCommandInvocation(
+    binary: string,
+    args: string[],
+): OpenCodeCommandInvocation {
+    const extension = extname(binary).toLowerCase();
+    if (extension !== ".cmd" && extension !== ".bat") {
+        return { command: binary, args };
+    }
+
+    const command = process.env.ComSpec?.trim() || process.env.COMSPEC?.trim() || "cmd.exe";
+    // cmd.exe needs the /c payload as one outer-quoted command string. Pass the
+    // binary through the child environment so percent signs in a valid path are
+    // not treated as another variable expansion. Current callers only supply the
+    // fixed `--version` and `models` arguments.
+    const commandLine = [`%${OPENCODE_BINARY_ENV}%`, ...args]
+        .map((part) => `"${part}"`)
+        .join(" ");
+    return {
+        command,
+        args: ["/d", "/s", "/v:off", "/c", `"${commandLine}"`],
+        env: { [OPENCODE_BINARY_ENV]: binary },
+        windowsVerbatimArguments: true,
+    };
+}
 
 /**
  * Run `opencode <args>`. If a `binary` path is given (an absolute path resolved
  * for a stock `~/.opencode/bin` install or a version-manager shim that is not on
- * PATH), call that exact path via execFile; otherwise fall back to a bare
+ * PATH), invoke that exact path; otherwise fall back to a bare
  * `opencode` on PATH.
  */
 function runOpenCode(args: string[], binary?: string | null, timeoutMs?: number): string | null {
     try {
         const options = { stdio: "pipe" as const, ...(timeoutMs ? { timeout: timeoutMs } : {}) };
         if (binary) {
-            return execFileSync(binary, args, options).toString().trim();
+            const invocation = getOpenCodeCommandInvocation(binary, args);
+            return execFileSync(invocation.command, invocation.args, {
+                ...options,
+                ...(invocation.env ? { env: { ...process.env, ...invocation.env } } : {}),
+                ...(invocation.windowsVerbatimArguments ? { windowsVerbatimArguments: true } : {}),
+            })
+                .toString()
+                .trim();
         }
         return execSync(`opencode ${args.join(" ")}`, options)
             .toString()


### PR DESCRIPTION
## Summary

- run detected OpenCode `.cmd` and `.bat` shims through `ComSpec` on Windows, because Node's `execFileSync` cannot execute command shims directly
- preserve direct invocation for native executables and pass the shim path through the child environment so spaces, shell metacharacters, and literal `%VAR%` text remain intact
- add coverage for case-insensitive shim extensions, native binaries, version/model probes, and tricky Windows paths

This restores OpenCode detection for npm-installed Windows users while keeping the existing timeout and native-executable behavior.

## Verification

- `bun test packages/cli/src/lib/opencode-helpers.test.ts` (`25` passed, `10` platform skips, `0` failed)
- production Bun build of `packages/cli/src/lib/opencode-helpers.ts`
- real Windows `npm.cmd` smoke test (returned version `11.16.0`)
- `git diff --check`

Full workspace typecheck and lint were not run because dependency bootstrap could not complete in this environment: Bun registry metadata resolution failed, and the npm workspace install timed out.

Fixes #255

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/magic-context/pr/261"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787998442&installation_model_id=22398&pr_number=261&repository=cortexkit%2Fmagic-context&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Fmagic-context%2Fpull%2F261&signature=7c17292acaf85992f6bb4bbd227b77cf9c4bde280fa5096201e38e0573c9e20d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores Windows OpenCode detection for npm-installed users. Uses a safer invocation path for command shims while preserving native binary behavior and timeouts.

- **Bug Fixes**
  - Route `.cmd`/`.bat` shims through `ComSpec` (fallback `cmd.exe`) with a single quoted `/c` payload and `windowsVerbatimArguments`.
  - Pass the shim path via `MAGIC_CONTEXT_OPENCODE_BINARY` to prevent extra expansion and keep spaces, metacharacters, and literal `%VAR%` intact.
  - Invoke native executables directly; timeout behavior unchanged.
  - Add tests for case-insensitive shim extensions, version/model probes, native binaries, and tricky Windows paths.

<sup>Written for commit 47ca8f6bc1d4ccc3969a966db623a20c12c3b009. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/magic-context/pull/261?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR restores OpenCode probing for Windows command shims.
- Routes case-insensitive `.cmd` and `.bat` paths through `ComSpec`.
- Preserves direct execution for native binaries.
- Passes shim paths through the child environment to preserve special characters.
- Adds tests for shim routing, native invocation, version probes, model probes, and tricky paths.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete changed-code failure identified.

Current production paths supply command shims only on Windows, and the new invocation preserves exact shim paths while retaining direct execution for native binaries.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/cli/src/lib/opencode-helpers.ts | Adds targeted Windows command-shim invocation while preserving existing native executable and timeout behavior; no actionable defect identified. |
| packages/cli/src/lib/opencode-helpers.test.ts | Adds focused coverage for command construction and end-to-end version and model probing through command shims. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(cli): execute OpenCode command shims..."](https://github.com/cortexkit/magic-context/commit/47ca8f6bc1d4ccc3969a966db623a20c12c3b009) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48641511)</sub>

<!-- /greptile_comment -->