### PR TITLE
Add MiniMax tokenizer calibration support

### DIFF
--- a/packages/plugin/scripts/calibrate-tokenizer/models.json
+++ b/packages/plugin/scripts/calibrate-tokenizer/models.json
@@ -132,6 +132,30 @@
             "provider": "openrouter",
             "modelId": "anthropic/claude-sonnet-4.6",
             "tokenizerKey": "anthropic/claude-sonnet-4.5"
+        },
+        {
+            "label": "minimax/MiniMax-M3",
+            "provider": "minimax",
+            "modelId": "MiniMax-M3",
+            "tokenizerKey": null
+        },
+        {
+            "label": "minimax/MiniMax-M2.7",
+            "provider": "minimax",
+            "modelId": "MiniMax-M2.7",
+            "tokenizerKey": null
+        },
+        {
+            "label": "minimax-cn/MiniMax-M3",
+            "provider": "minimax-cn",
+            "modelId": "MiniMax-M3",
+            "tokenizerKey": null
+        },
+        {
+            "label": "minimax-cn/MiniMax-M2.7",
+            "provider": "minimax-cn",
+            "modelId": "MiniMax-M2.7",
+            "tokenizerKey": null
         }
     ]
 }

--- a/packages/plugin/scripts/calibrate-tokenizer/providers/openai-compatible.test.ts
+++ b/packages/plugin/scripts/calibrate-tokenizer/providers/openai-compatible.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+
+import { measureOpenAICompatible } from "./openai-compatible";
+
+const originalFetch = globalThis.fetch;
+const modelCatalog = JSON.parse(
+    readFileSync(new URL("../models.json", import.meta.url), "utf-8"),
+) as {
+    tests: Array<{ provider: string; modelId: string }>;
+};
+
+afterEach(() => {
+    globalThis.fetch = originalFetch;
+});
+
+async function expectProviderEndpoint(provider: string, expectedUrl: string): Promise<void> {
+    const urls: string[] = [];
+    const totals = [10, 30, 50];
+    globalThis.fetch = (async (input: string | URL | Request) => {
+        urls.push(String(input));
+        const promptTokens = totals[urls.length - 1];
+        return new Response(JSON.stringify({ usage: { prompt_tokens: promptTokens } }), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+        });
+    }) as typeof fetch;
+
+    const result = await measureOpenAICompatible(
+        {
+            label: `${provider}/MiniMax-M3`,
+            provider,
+            modelId: "MiniMax-M3",
+        },
+        { type: "api", key: "test-key" },
+        "system prompt",
+        [{ name: "tool", description: "Tool", input_schema: { type: "object" } }],
+    );
+
+    expect(urls).toEqual([expectedUrl, expectedUrl, expectedUrl]);
+    expect(result).toEqual({ systemApi: 20, toolsApi: 40 });
+}
+
+describe("measureOpenAICompatible", () => {
+    it("catalogs both current MiniMax models for each regional route", () => {
+        for (const provider of ["minimax", "minimax-cn"]) {
+            const modelIds = modelCatalog.tests
+                .filter((test) => test.provider === provider)
+                .map((test) => test.modelId);
+            expect(modelIds).toEqual(["MiniMax-M3", "MiniMax-M2.7"]);
+        }
+    });
+
+    it("routes MiniMax global calibration requests", async () => {
+        await expectProviderEndpoint(
+            "minimax",
+            "https://api.minimax.io/v1/chat/completions",
+        );
+    });
+
+    it("routes MiniMax China calibration requests", async () => {
+        await expectProviderEndpoint(
+            "minimax-cn",
+            "https://api.minimaxi.com/v1/chat/completions",
+        );
+    });
+});

--- a/packages/plugin/scripts/calibrate-tokenizer/providers/openai-compatible.ts
+++ b/packages/plugin/scripts/calibrate-tokenizer/providers/openai-compatible.ts
@@ -106,6 +106,20 @@ function endpointFor(provider: string, auth: AuthEntry): ProviderEndpoint {
                 maxTokensField: "max_tokens",
                 supportsTools: true,
             };
+        case "minimax":
+            return {
+                url: "https://api.minimax.io/v1/chat/completions",
+                headers,
+                maxTokensField: "max_tokens",
+                supportsTools: true,
+            };
+        case "minimax-cn":
+            return {
+                url: "https://api.minimaxi.com/v1/chat/completions",
+                headers,
+                maxTokensField: "max_tokens",
+                supportsTools: true,
+            };
         default:
             throw new Error(`Unknown provider: ${provider}`);
     }


### PR DESCRIPTION
Reason: Add first-party MiniMax tokenizer calibration support for the current text models and both regional OpenAI-compatible endpoints.

Changes:
- Route `minimax` and `minimax-cn` calibration requests to their respective chat-completions endpoints.
- Catalog `MiniMax-M3` and `MiniMax-M2.7` for both regional routes.
- Test endpoint selection and the existing prompt/tool token delta parsing.

Checks:
- `bun test packages/plugin/scripts/calibrate-tokenizer/providers/openai-compatible.test.ts`
- `bun run --cwd packages/plugin typecheck`
- `git diff --check`
- `jq -e '.tests | length > 0' packages/plugin/scripts/calibrate-tokenizer/models.json`
- `bun run --cwd packages/plugin lint` (currently fails on unrelated existing diagnostics and the checked-in Biome schema version mismatch)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/magic-context/pr/265"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788161778&installation_model_id=22398&pr_number=265&repository=cortexkit%2Fmagic-context&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Fmagic-context%2Fpull%2F265&signature=fb5e0eb88128708f5039643c90288724a7b25ef1f43248d4c372cda26c0eb6bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add MiniMax tokenizer calibration for `MiniMax-M3` and `MiniMax-M2.7` across global and China OpenAI‑compatible endpoints. This enables measuring system and tool token deltas for MiniMax via chat completions.

- **New Features**
  - Route `minimax` to https://api.minimax.io/v1/chat/completions and `minimax-cn` to https://api.minimaxi.com/v1/chat/completions.
  - Catalog `MiniMax-M3` and `MiniMax-M2.7` under both providers in `models.json`.
  - Add tests for endpoint selection and prompt/tool token delta parsing.

<sup>Written for commit c4ffff6f851a39f36454a7edc0449cf3f660549a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/magic-context/pull/265?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds tokenizer-calibration coverage for MiniMax’s current text models across its global and China OpenAI-compatible endpoints.
- Adds MiniMax-M3 and MiniMax-M2.7 catalog entries for both regional provider identifiers.
- Routes each provider identifier to its corresponding chat-completions endpoint.
- Tests regional endpoint selection, catalog coverage, and the existing baseline-relative prompt and tool token calculations.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable correctness or security failures identified.

The added provider identifiers route to distinct supported endpoints, the catalog entries follow existing runner contracts, and the tests exercise both regional routes and token-delta calculations.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/plugin/scripts/calibrate-tokenizer/models.json | Adds distinct global and China calibration entries for MiniMax-M3 and MiniMax-M2.7 using the runner’s documented null-tokenizer fallback. |
| packages/plugin/scripts/calibrate-tokenizer/providers/openai-compatible.ts | Adds explicit MiniMax regional endpoint mappings using the existing OpenAI-compatible authentication, payload, and usage-parsing path. |
| packages/plugin/scripts/calibrate-tokenizer/providers/openai-compatible.test.ts | Verifies model catalog coverage, regional endpoint routing, and the existing baseline-relative prompt and tool token calculations. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  C[MiniMax calibration catalog entry] --> P{Provider}
  P -->|minimax| G[api.minimax.io]
  P -->|minimax-cn| CN[api.minimaxi.com]
  G --> R[OpenAI-compatible chat completions]
  CN --> R
  R --> U[Read usage.prompt_tokens]
  U --> D[Calculate system and tool deltas]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(calibration): add MiniMax provider ..."](https://github.com/cortexkit/magic-context/commit/c4ffff6f851a39f36454a7edc0449cf3f660549a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49298386)</sub>

<!-- /greptile_comment -->