### PR TITLE
fix(transform): make the mid-turn release valve actually detect injections

### DIFF
--- a/packages/plugin/src/hooks/magic-context/read-session-db.test.ts
+++ b/packages/plugin/src/hooks/magic-context/read-session-db.test.ts
@@ -151,11 +151,17 @@ describe("isMidTurnFromOpenCodeDb", () => {
     it("does not release mid-turn for marker-part user messages after a stale tool-calls tail", () => {
         const db = createMidTurnDb();
         insertAssistant(db, "session-1", "assistant-1", { finish: "tool-calls" }, 100);
-        insertUser(db, "session-1", "user-1", { content: "inbox notification" }, 200);
+        insertUser(db, "session-1", "user-1", { content: "✉ Inbox from peer" }, 200);
         insertPart(db, "session-1", "user-1", "part-1", {
             type: "text",
             text: "✉ Inbox from peer",
-            metadata: { marker: { kind: "inbox" } },
+            metadata: {
+                marker: {
+                    kind: "inbox",
+                    from: "Peer Session",
+                    sessionId: "ses_peer0000000000000000000",
+                },
+            },
         });
 
         expect(isMidTurnFromOpenCodeDb(db, "session-1")).toBe(true);
@@ -208,6 +214,87 @@ describe("isMidTurnFromOpenCodeDb", () => {
         const db = createMidTurnDb();
 
         expect(isMidTurnFromOpenCodeDb(db, "session-1")).toBe(false);
+    });
+
+    it("does not release mid-turn for an ignored-only user part after a stale tool-calls tail", () => {
+        const db = createMidTurnDb();
+        insertAssistant(db, "session-1", "assistant-1", { finish: "tool-calls" }, 100);
+        insertUser(db, "session-1", "user-1", { content: "status notification" }, 200);
+        insertPart(db, "session-1", "user-1", "part-1", {
+            type: "text",
+            text: "## Claude Routing Status",
+            ignored: true,
+        });
+
+        expect(isMidTurnFromOpenCodeDb(db, "session-1")).toBe(true);
+    });
+
+    it("releases mid-turn when a user message has an ignored part AND a real text part", () => {
+        const db = createMidTurnDb();
+        insertAssistant(db, "session-1", "assistant-1", { finish: "tool-calls" }, 100);
+        insertUser(db, "session-1", "user-1", { content: "notification + real input" }, 200);
+        insertPart(db, "session-1", "user-1", "part-1", {
+            type: "text",
+            text: "## Claude Quotas",
+            ignored: true,
+        });
+        insertPart(db, "session-1", "user-1", "part-2", {
+            type: "text",
+            text: "actually do the thing",
+        });
+
+        expect(isMidTurnFromOpenCodeDb(db, "session-1")).toBe(false);
+    });
+
+    it("does not release mid-turn when ignored is numeric 1 (truthy variant)", () => {
+        const db = createMidTurnDb();
+        insertAssistant(db, "session-1", "assistant-1", { finish: "tool-calls" }, 100);
+        insertUser(db, "session-1", "user-1", { content: "status notification" }, 200);
+        insertPart(db, "session-1", "user-1", "part-1", {
+            type: "text",
+            text: "## Claude Quotas",
+            ignored: 1,
+        });
+
+        expect(isMidTurnFromOpenCodeDb(db, "session-1")).toBe(true);
+    });
+
+    it("does not release mid-turn for interrupt marker parts after a stale tool-calls tail", () => {
+        const db = createMidTurnDb();
+        insertAssistant(db, "session-1", "assistant-1", { finish: "tool-calls" }, 100);
+        insertUser(db, "session-1", "user-1", { content: "interrupt" }, 200);
+        insertPart(db, "session-1", "user-1", "part-1", {
+            type: "text",
+            text: "interrupt",
+            metadata: {
+                marker: {
+                    kind: "interrupt",
+                    intent: "abort",
+                    origin: "parent",
+                },
+            },
+        });
+
+        expect(isMidTurnFromOpenCodeDb(db, "session-1")).toBe(true);
+    });
+
+    it("does not release mid-turn for message marker parts after a stale tool-calls tail", () => {
+        const db = createMidTurnDb();
+        insertAssistant(db, "session-1", "assistant-1", { finish: "tool-calls" }, 100);
+        insertUser(db, "session-1", "user-1", { content: "peer message" }, 200);
+        insertPart(db, "session-1", "user-1", "part-1", {
+            type: "text",
+            text: "peer message",
+            metadata: {
+                marker: {
+                    kind: "message",
+                    peer: "subagent",
+                    expectReply: false,
+                },
+            },
+        });
+
+        expect(isMidTurnFromOpenCodeDb(db, "session-1")).toBe(true);
     });
 });
 

--- a/packages/plugin/src/hooks/magic-context/read-session-db.test.ts
+++ b/packages/plugin/src/hooks/magic-context/read-session-db.test.ts
@@ -93,10 +93,15 @@ describe("isMidTurnFromOpenCodeDb", () => {
         expect(isMidTurnFromOpenCodeDb(db, "session-1")).toBe(false);
     });
 
-    it("does not release mid-turn for synthetic user messages after a stale tool-calls tail", () => {
+    it("does not release mid-turn for synthetic-part user messages after a stale tool-calls tail", () => {
         const db = createMidTurnDb();
         insertAssistant(db, "session-1", "assistant-1", { finish: "tool-calls" }, 100);
-        insertUser(db, "session-1", "user-1", { content: "agent nudge", synthetic: true }, 200);
+        insertUser(db, "session-1", "user-1", { content: "agent nudge" }, 200);
+        insertPart(db, "session-1", "user-1", "part-1", {
+            type: "text",
+            text: "agent nudge",
+            synthetic: true,
+        });
 
         expect(isMidTurnFromOpenCodeDb(db, "session-1")).toBe(true);
     });
@@ -139,6 +144,62 @@ describe("isMidTurnFromOpenCodeDb", () => {
         const db = createMidTurnDb();
         insertAssistant(db, "session-1", "assistant-1", { finish: "stop" });
         insertPart(db, "session-1", "assistant-1", "part-1", { type: "text", text: "done" });
+
+        expect(isMidTurnFromOpenCodeDb(db, "session-1")).toBe(false);
+    });
+
+    it("does not release mid-turn for marker-part user messages after a stale tool-calls tail", () => {
+        const db = createMidTurnDb();
+        insertAssistant(db, "session-1", "assistant-1", { finish: "tool-calls" }, 100);
+        insertUser(db, "session-1", "user-1", { content: "inbox notification" }, 200);
+        insertPart(db, "session-1", "user-1", "part-1", {
+            type: "text",
+            text: "✉ Inbox from peer",
+            metadata: { marker: { kind: "inbox" } },
+        });
+
+        expect(isMidTurnFromOpenCodeDb(db, "session-1")).toBe(true);
+    });
+
+    it("releases mid-turn for an @mention operator prompt with a synthetic agent part", () => {
+        const db = createMidTurnDb();
+        insertAssistant(db, "session-1", "assistant-1", { finish: "tool-calls" }, 100);
+        insertUser(db, "session-1", "user-1", { content: "do the thing @research-deep" }, 200);
+        insertPart(db, "session-1", "user-1", "part-1", {
+            type: "text",
+            text: "do the thing @research-deep",
+        });
+        insertPart(db, "session-1", "user-1", "part-2", {
+            type: "agent",
+            name: "research-deep",
+            synthetic: true,
+        });
+
+        expect(isMidTurnFromOpenCodeDb(db, "session-1")).toBe(false);
+    });
+
+    it("releases mid-turn for a partless user message (vacuous-ALL fence)", () => {
+        const db = createMidTurnDb();
+        insertAssistant(db, "session-1", "assistant-1", { finish: "tool-calls" }, 100);
+        insertUser(db, "session-1", "user-1", { content: "new turn" }, 200);
+        // No parts inserted — partless messages must count as real.
+
+        expect(isMidTurnFromOpenCodeDb(db, "session-1")).toBe(false);
+    });
+
+    it("releases mid-turn when a user message has a marker part AND a real text part", () => {
+        const db = createMidTurnDb();
+        insertAssistant(db, "session-1", "assistant-1", { finish: "tool-calls" }, 100);
+        insertUser(db, "session-1", "user-1", { content: "real input with marker" }, 200);
+        insertPart(db, "session-1", "user-1", "part-1", {
+            type: "text",
+            text: "✉ Inbox from peer",
+            metadata: { marker: { kind: "inbox" } },
+        });
+        insertPart(db, "session-1", "user-1", "part-2", {
+            type: "text",
+            text: "real input with marker",
+        });
 
         expect(isMidTurnFromOpenCodeDb(db, "session-1")).toBe(false);
     });

--- a/packages/plugin/src/hooks/magic-context/read-session-db.ts
+++ b/packages/plugin/src/hooks/magic-context/read-session-db.ts
@@ -150,6 +150,7 @@ function hasNewerRealUserMessage(
                    WHERE p.message_id = m.id
                      AND COALESCE(json_extract(p.data, '$.synthetic'), 0) NOT IN (1, 'true')
                      AND json_extract(p.data, '$.metadata.marker.kind') IS NULL
+                     AND COALESCE(json_extract(p.data, '$.ignored'), 0) NOT IN (1, 'true')
                  )
                )
              LIMIT 1`,
@@ -159,15 +160,19 @@ function hasNewerRealUserMessage(
     // on the message row. So separating injected from real user messages requires
     // a part join. A user message is injected iff it HAS at least one part AND
     // EVERY part is machine-generated — where a part is machine-generated if it
-    // carries either synthetic=true or a marker part (metadata.marker.kind).
-    // Marker parts are deliberately NON-synthetic so the TUI renders them as
-    // visible system-event lines; they are identified structurally. ALL-parts
-    // semantics is load-bearing: a real operator prompt may include a synthetic
-    // `agent` part from an @mention — classifying that as injected would release
-    // the mid-turn lock on genuine human input (the inverse bug, and worse).
-    // The EXISTS guard on part rows is the vacuous-ALL fence: a partless message
-    // satisfies "every part is machine-generated" trivially, so it must count as
-    // real to avoid incorrectly suppressing a lock release.
+    // carries either synthetic=true, a marker part (metadata.marker.kind), or
+    // an ignored flag. Marker parts are deliberately NON-synthetic so the TUI
+    // renders them as visible system-event lines; they are identified
+    // structurally. Ignored parts are dropped by opencode's own model-facing
+    // serializer (message-v2.ts:206): an ignored text part is never pushed into
+    // the model-facing message, so a message whose parts are all ignored cannot
+    // constitute a real user turn. ALL-parts semantics is load-bearing: a real
+    // operator prompt may include a synthetic `agent` part from an @mention —
+    // classifying that as injected would release the mid-turn lock on genuine
+    // human input (the inverse bug, and worse). The EXISTS guard on part rows is
+    // the vacuous-ALL fence: a partless message satisfies "every part is
+    // machine-generated" trivially, so it must count as real to avoid incorrectly
+    // suppressing a lock release.
     return row?.one === 1;
 }
 

--- a/packages/plugin/src/hooks/magic-context/read-session-db.ts
+++ b/packages/plugin/src/hooks/magic-context/read-session-db.ts
@@ -139,18 +139,35 @@ function hasNewerRealUserMessage(
     const row = db
         .prepare(
             `SELECT 1 as one
-             FROM message
-             WHERE session_id = ?
-               AND time_created > ?
-               AND json_extract(data, '$.role') = 'user'
-               AND COALESCE(json_extract(data, '$.synthetic'), 0) NOT IN (1, 'true')
+             FROM message m
+             WHERE m.session_id = ?
+               AND m.time_created > ?
+               AND json_extract(m.data, '$.role') = 'user'
+               AND NOT (
+                 EXISTS (SELECT 1 FROM part p WHERE p.message_id = m.id)
+                 AND NOT EXISTS (
+                   SELECT 1 FROM part p
+                   WHERE p.message_id = m.id
+                     AND COALESCE(json_extract(p.data, '$.synthetic'), 0) NOT IN (1, 'true')
+                     AND json_extract(p.data, '$.metadata.marker.kind') IS NULL
+                 )
+               )
              LIMIT 1`,
         )
         .get(sessionId, latestAssistantTimeCreated) as ExistenceRow | null;
-    // OpenCode persists promptAsync/channel-2 synthetic prompts as
-    // message.info.synthetic, which is the top-level $.synthetic field in the
-    // message table's data JSON. Those agent-directed nudges should not end a
-    // still-accumulating tool-use turn, but a later real user message does.
+    // OpenCode persists synthetic as an annotation on the PART row's data, never
+    // on the message row. So separating injected from real user messages requires
+    // a part join. A user message is injected iff it HAS at least one part AND
+    // EVERY part is machine-generated — where a part is machine-generated if it
+    // carries either synthetic=true or a marker part (metadata.marker.kind).
+    // Marker parts are deliberately NON-synthetic so the TUI renders them as
+    // visible system-event lines; they are identified structurally. ALL-parts
+    // semantics is load-bearing: a real operator prompt may include a synthetic
+    // `agent` part from an @mention — classifying that as injected would release
+    // the mid-turn lock on genuine human input (the inverse bug, and worse).
+    // The EXISTS guard on part rows is the vacuous-ALL fence: a partless message
+    // satisfies "every part is machine-generated" trivially, so it must count as
+    // real to avoid incorrectly suppressing a lock release.
     return row?.one === 1;
 }
 


### PR DESCRIPTION
## The bug

`hasNewerRealUserMessage` (`read-session-db.ts:133`) decides whether a newer *real* user message exists after the latest assistant turn — `isMidTurnFromOpenCodeDb` uses it to release the mid-turn lock. It filtered on `$.synthetic` on the **message** row:

```sql
AND COALESCE(json_extract(data, '$.synthetic'), 0) NOT IN (1, 'true')
```

OpenCode persists `synthetic` on the **part** row's data, never on the message row. Measured on a live `opencode.db`:

| probe | rows |
| --- | --- |
| `json_extract(data,'$.synthetic')` on `message` | **0** |
| `json_extract(data,'$.synthetic')` on `part` | **11,320** |

So the predicate is always true. Every synthetic injection — Channel-2 ceiling nudges, s2s frames, subagent-message notifications — counts as a real user message and releases the mid-turn lock while a turn is still accumulating tool calls. The lock exists so the transform never rewrites bytes mid-turn, so this quietly gives up that protection.

Two things kept it hidden: the comment above the return asserted the opposite ("OpenCode persists promptAsync/channel-2 synthetic prompts as `message.info.synthetic`, which is the top-level `$.synthetic` field in the message table's data JSON"), and the existing test fixtured `synthetic: true` on the message row — a shape production never produces, which passes only *because* the filter reads that field. Comment and test agreed with each other and both were wrong.

## The fix

A part join. A part is machine-generated iff it carries `synthetic: true` **OR** a `metadata.marker.kind`; a user message is injected iff it **HAS parts AND EVERY part** is machine-generated.

All three pieces are load-bearing, and each was found by measurement rather than reasoning:

**1. `marker.kind` is required.** Marker parts — s2s inbox lines, subagent-message notifications, steer/cancel notices — are deliberately **non-synthetic** so the TUI renders them as visible system-event lines (`packages/tui/src/routes/session/index.tsx` ≈1431-1441: `!x.synthetic && metadata.marker.kind !== undefined`). They're tagged structurally instead. Live counts: 1,778 such parts (`message` 847, `inbox` 683, `interrupt` 248). Testing `synthetic` alone misses all of them.

**2. ALL-parts, not ANY.** 1,813 user messages carry a synthetic part *and* a non-synthetic companion. Of those, 525 are genuine operator prompts that used an `@mention` — the mention adds a synthetic `agent` part beside real human text. ANY-semantics would classify those live human turns as injected and suppress the lock on real input: the inverse bug, and worse than the original.

**3. The `EXISTS (… FROM part …)` clause is the vacuous-ALL fence.** A partless user message satisfies "every part is machine-generated" trivially and must count as real. Partless user rows do occur — 4 of 19,004 on the box measured — so this is a live case, not a theoretical one.

The misleading comment is replaced with one that states where `synthetic` actually lives and why each clause exists.

## Tests

Rewrote the existing synthetic test to fixture the part-level shape (it still expects `true` — still mid-turn), and added four cases:

| case | expectation | guards |
| --- | --- | --- |
| synthetic **part** after stale tool-calls tail | mid-turn `true` | the original bug |
| marker part (`metadata.marker.kind: "inbox"`) | mid-turn `true` | the `marker.kind` clause |
| `@mention` operator prompt (real text + synthetic `agent` part) | releases → `false` | ANY-semantics inversion |
| partless user message | releases → `false` | vacuous-ALL fence |
| marker part + plain operator text | releases → `false` | mixed-parts |

The synthetic-part and marker-part cases are red-verified against the unfixed query:

```
(fail) does not release mid-turn for synthetic-part user messages after a stale tool-calls tail
(fail) does not release mid-turn for marker-part user messages after a stale tool-calls tail
 18 pass / 2 fail
```
Restoring the fix: 20 pass / 0 fail.

## Gates

| gate | result |
| --- | --- |
| `read-session-db.test.ts` | 20 pass / 0 fail |
| plugin `bun test` | 3357 pass / 0 fail (clean-`master` baseline 3353; +4 net) |
| `tsc --noEmit` | clean |
| lint | no diagnostics in either touched file |

CI note: `Check (plugin)`, `Check (pi-plugin)` and `Check (dashboard)` are currently failing on `master` itself (`7af5961d`) with lint errors in files this PR doesn't touch — `compartment-chunk-embedding.ts`, `storage-git-commits.ts`, `render-mural.test.ts`, `embedding-local.test.ts` and others. This branch inherits that red; it doesn't add to it. Happy to include the lint cleanup here if you'd rather, but it seemed wrong to bundle unrelated fixes into a behavioral change.

## Note on scope

I deliberately did **not** propose tagging the marker/companion parts `synthetic` to make a single-flag test work — that would erase every ✉/⊘ system-event line from the operator's transcript, per the TUI predicate above. Separately worth flagging for maintainers: `metadata.marker.kind` appears to be the real "machine-generated" discriminator but isn't documented as such, so a consumer reaching for the obvious `synthetic` flag gets the classification wrong in *both* directions. A short note in the docs, or a dedicated `systemGenerated` field, would prevent the next consumer repeating this. Happy to file that separately if useful.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/magic-context/pr/273"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788544849&installation_model_id=22398&pr_number=273&repository=cortexkit%2Fmagic-context&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Fmagic-context%2Fpull%2F273&signature=6f97917b93caf3e822e45a7ec6cdc9447830771d8ef27df3367314ab9497bd91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes mid-turn lock detection so synthetic, marker-only, and ignored-only user messages no longer release the lock. This prevents premature unlocks while tool calls are still running.

- **Bug Fixes**
  - Detect injections at the part level; a user message is injected only if it has parts and every part is machine-generated (`synthetic`, `metadata.marker.kind`, or `ignored`).
  - Add an EXISTS guard so partless user messages count as real input.
  - Update tests with real marker shapes and cases for @mentions/mixed parts, partless, ignored-only, ignored+real text, numeric `ignored: 1`, and interrupt/message markers.

<sup>Written for commit 1ce9b36f5a4970e156e2f3415afd36b8d9d4dd66. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/magic-context/pull/273?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR corrects mid-turn release detection by classifying user messages from their associated parts instead of a nonexistent message-level synthetic flag.
- Treats messages as injected only when they contain parts and every part is synthetic, marker-tagged, or ignored.
- Preserves real-user classification for partless and mixed-part messages.
- Expands coverage for synthetic, marker, ignored, mixed, partless, and `@mention` message shapes.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/plugin/src/hooks/magic-context/read-session-db.ts | Replaces the ineffective message-level synthetic check with all-parts classification and a partless-message guard. |
| packages/plugin/src/hooks/magic-context/read-session-db.test.ts | Adds representative coverage for synthetic, marker, ignored, mixed, partless, and mention-bearing user messages. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Newer user message] --> B{Has parts?}
    B -- No --> R[Real user message: release lock]
    B -- Yes --> C{Every part synthetic, marker-tagged, or ignored?}
    C -- Yes --> I[Injected message: keep lock]
    C -- No --> R
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(transform): treat ignored-only user ..."](https://github.com/cortexkit/magic-context/commit/1ce9b36f5a4970e156e2f3415afd36b8d9d4dd66) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50524377)</sub>

<!-- /greptile_comment -->