### PR TITLE
fix(tui): import Solid control-flow builtins from solid-js, not @opentui/solid

### DIFF
--- a/packages/plugin/scripts/build-tui.ts
+++ b/packages/plugin/scripts/build-tui.ts
@@ -2,20 +2,12 @@ import { copyFile, mkdir, readdir, readFile, rm, writeFile } from "node:fs/promi
 import { createRequire } from "node:module";
 import { basename, dirname, join, relative } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
+import { runtimeModuleId, TUI_RUNTIME_SPECIFIERS } from "../src/shared/tui-runtime-specifiers";
 
 const pluginRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
 const sourceRoot = join(pluginRoot, "src/tui");
 const outputRoot = join(pluginRoot, "src/tui-compiled");
-const runtimeSpecifiers = new Set([
-    "@opentui/core",
-    "@opentui/core/testing",
-    "@opentui/solid",
-    "@opentui/solid/components",
-    "@opentui/solid/jsx-runtime",
-    "@opentui/solid/jsx-dev-runtime",
-    "solid-js",
-    "solid-js/store",
-]);
+const runtimeSpecifiers: Set<string> = new Set(TUI_RUNTIME_SPECIFIERS);
 
 type TransformSolidSource = (
     code: string,
@@ -30,8 +22,82 @@ type SolidTransformModule = {
     transformSolidSource?: TransformSolidSource;
 };
 
-function runtimeModuleId(specifier: string): string {
-    return `opentui:runtime-module:${encodeURIComponent(specifier)}`;
+
+/**
+ * The Solid transform emits every runtime helper AND every control-flow builtin
+ * (`For`, `Show`, `Index`, `Switch`, `Match`, `ErrorBoundary`, `Suspense`, ...)
+ * as an import from a single `moduleName`, which we set to `@opentui/solid`.
+ * But `@opentui/solid` only re-exports its own renderer helpers: the builtins
+ * live in `solid-js`. An emitted `import { For } from "@opentui/solid"` therefore
+ * resolves against the host's registry and throws
+ *
+ *     Export named 'For' not found in module 'opentui:runtime-module:@opentui/solid'
+ *
+ * which the host swallows, leaving no sidebar and no /ctx-* commands.
+ *
+ * Rather than hardcode the split (it moves between OpenTUI versions), read the
+ * real export sets at build time and redirect only the names the OpenTUI runtime
+ * genuinely lacks. A name missing from BOTH modules fails the build instead of
+ * shipping a bundle that silently breaks the TUI.
+ */
+async function loadRuntimeExportSets(): Promise<{
+    openTui: Set<string>;
+    solid: Set<string>;
+}> {
+    const [openTuiModule, solidModule] = await Promise.all([
+        import("@opentui/solid"),
+        import("solid-js"),
+    ]);
+    return {
+        openTui: new Set(Object.keys(openTuiModule)),
+        solid: new Set(Object.keys(solidModule)),
+    };
+}
+
+const OPENTUI_SOLID_RUNTIME_ID = runtimeModuleId("@opentui/solid");
+const SOLID_JS_RUNTIME_ID = runtimeModuleId("solid-js");
+
+// The transform emits one specifier per import statement, e.g.
+//   import { For as _$For } from "opentui:runtime-module:%40opentui%2Fsolid";
+const SINGLE_SPECIFIER_IMPORT =
+    /^import \{\s*([A-Za-z_$][\w$]*)(\s+as\s+[A-Za-z_$][\w$]*)?\s*\} from "([^"]+)";$/;
+
+function redirectBuiltinImports(
+    code: string,
+    exportSets: { openTui: Set<string>; solid: Set<string> },
+    sourceFile: string,
+): string {
+    const unresolved: string[] = [];
+
+    const rewritten = code
+        .split("\n")
+        .map((line) => {
+            const match = SINGLE_SPECIFIER_IMPORT.exec(line);
+            if (!match) return line;
+
+            const [, importedName, alias, moduleId] = match;
+            if (moduleId !== OPENTUI_SOLID_RUNTIME_ID) return line;
+            if (exportSets.openTui.has(importedName)) return line;
+
+            if (!exportSets.solid.has(importedName)) {
+                unresolved.push(importedName);
+                return line;
+            }
+
+            return `import {${alias ? ` ${importedName}${alias} ` : ` ${importedName} `}} from "${SOLID_JS_RUNTIME_ID}";`;
+        })
+        .join("\n");
+
+    if (unresolved.length > 0) {
+        throw new Error(
+            `${sourceFile}: compiled TUI imports ${unresolved
+                .map((name) => `'${name}'`)
+                .join(", ")} which neither @opentui/solid nor solid-js exports. ` +
+                "Shipping this bundle would make the host drop the sidebar silently.",
+        );
+    }
+
+    return rewritten;
 }
 
 function asTransformSolidSource(mod: SolidTransformModule, from: string): TransformSolidSource {
@@ -113,6 +179,7 @@ async function compileTsx(
     transformSolidSource: TransformSolidSource,
     sourceFile: string,
     outputFile: string,
+    exportSets: { openTui: Set<string>; solid: Set<string> },
 ): Promise<void> {
     const code = await readFile(sourceFile, "utf8");
     const compiled = await transformSolidSource(code, {
@@ -123,10 +190,11 @@ async function compileTsx(
     });
 
     await mkdir(dirname(outputFile), { recursive: true });
-    await writeFile(outputFile, compiled);
+    await writeFile(outputFile, redirectBuiltinImports(compiled, exportSets, sourceFile));
 }
 
 const transformSolidSource = await loadTransformSolidSource();
+const runtimeExportSets = await loadRuntimeExportSets();
 const files = await listSourceFiles(sourceRoot);
 
 await rm(outputRoot, { recursive: true, force: true });
@@ -142,7 +210,7 @@ for (const sourceFile of files) {
         // the sidebar freezes on its first paint. The virtual ids are required so
         // the compiled package binds the host process's single OpenTUI/Solid
         // runtime instead of loading a second copy from the plugin package.
-        await compileTsx(transformSolidSource, sourceFile, outputFile);
+        await compileTsx(transformSolidSource, sourceFile, outputFile, runtimeExportSets);
     } else {
         await copyPlainTypeScript(sourceFile, outputFile);
     }

--- a/packages/plugin/src/shared/tui-runtime-specifiers.ts
+++ b/packages/plugin/src/shared/tui-runtime-specifiers.ts
@@ -1,0 +1,32 @@
+/**
+ * The module specifiers the compiled TUI is allowed to resolve through OpenCode's
+ * process-wide OpenTUI runtime registry (`opentui:runtime-module:<encoded>`).
+ *
+ * Single source of truth, shared by `scripts/build-tui.ts` (which rewrites these
+ * specifiers during the Solid transform) and
+ * `src/tui/tui-compiled-runtime-imports.test.ts` (which verifies every emitted
+ * specifier names a real export). Keeping one list means the guard test cannot
+ * drift into skipping a specifier the build actually rewrites — a skipped
+ * specifier is exactly the silent hole the test exists to close.
+ *
+ * Lives in `src/shared/` rather than `src/tui/` on purpose: `build-tui.ts` copies
+ * every file under `src/tui/` into the shipped `src/tui-compiled/` bundle, and
+ * this list is build/test tooling that the runtime bundle must not carry.
+ */
+export const TUI_RUNTIME_SPECIFIERS = [
+    "@opentui/core",
+    "@opentui/core/testing",
+    "@opentui/solid",
+    "@opentui/solid/components",
+    "@opentui/solid/jsx-runtime",
+    "@opentui/solid/jsx-dev-runtime",
+    "solid-js",
+    "solid-js/store",
+] as const;
+
+export type TuiRuntimeSpecifier = (typeof TUI_RUNTIME_SPECIFIERS)[number];
+
+/** Virtual module id OpenCode registers for a runtime specifier. */
+export function runtimeModuleId(specifier: string): string {
+    return `opentui:runtime-module:${encodeURIComponent(specifier)}`;
+}

--- a/packages/plugin/src/tui-compiled/slots/sidebar-content.tsx
+++ b/packages/plugin/src/tui-compiled/slots/sidebar-content.tsx
@@ -1,4 +1,4 @@
-import { For as _$For } from "opentui:runtime-module:%40opentui%2Fsolid";
+import { For as _$For } from "opentui:runtime-module:solid-js";
 import { createComponent as _$createComponent } from "opentui:runtime-module:%40opentui%2Fsolid";
 import { createTextNode as _$createTextNode } from "opentui:runtime-module:%40opentui%2Fsolid";
 import { effect as _$effect } from "opentui:runtime-module:%40opentui%2Fsolid";

--- a/packages/plugin/src/tui/tui-compiled-runtime-imports.test.ts
+++ b/packages/plugin/src/tui/tui-compiled-runtime-imports.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, test } from "bun:test";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+import { TUI_RUNTIME_SPECIFIERS } from "../shared/tui-runtime-specifiers";
+
+/**
+ * Every `opentui:runtime-module:*` import in the compiled TUI bundle must name an
+ * export the target module actually has.
+ *
+ * The Solid transform routes ALL of its emitted imports — renderer helpers and
+ * control-flow builtins (`For`, `Show`, `Index`, `Switch`, `Match`, ...) alike —
+ * through the single `moduleName` that `scripts/build-tui.ts` passes it, which is
+ * `@opentui/solid`. But `@opentui/solid` only re-exports its own renderer
+ * helpers; the builtins live in `solid-js`. So a bundle built without the
+ * redirect in `build-tui.ts` contains
+ *
+ *     import { For as _$For } from "opentui:runtime-module:%40opentui%2Fsolid";
+ *
+ * and the host throws `Export named 'For' not found` while loading the plugin.
+ * OpenCode swallows that error, so the only visible symptom is a missing sidebar
+ * and missing /ctx-* commands — no crash and nothing on stderr.
+ *
+ * This test resolves each specifier against the real module export sets instead
+ * of a hardcoded list, so it keeps holding when OpenTUI changes which names it
+ * re-exports. It covers every specifier `build-tui.ts` rewrites (via the shared
+ * `TUI_RUNTIME_SPECIFIERS` list) and fails on any runtime module id outside that
+ * set, so a future import from e.g. `solid-js/store` cannot slip through
+ * unverified.
+ */
+describe("compiled TUI runtime imports", () => {
+    const COMPILED_ROOT = join(import.meta.dir, "..", "tui-compiled");
+    const IMPORT_PATTERN = /import \{([^}]+)\} from "opentui:runtime-module:([^"]+)"/g;
+
+    function compiledFiles(dir: string): string[] {
+        const found: string[] = [];
+        for (const entry of readdirSync(dir)) {
+            const full = join(dir, entry);
+            if (statSync(full).isDirectory()) {
+                found.push(...compiledFiles(full));
+            } else if (entry.endsWith(".ts") || entry.endsWith(".tsx")) {
+                found.push(full);
+            }
+        }
+        return found;
+    }
+
+    /** Export sets for EVERY specifier build-tui.ts rewrites, keyed by module id.
+     *  Built from the shared list so the test cannot cover fewer modules than the
+     *  build rewrites. */
+    async function loadExportSets(): Promise<Record<string, Set<string>>> {
+        const entries = await Promise.all(
+            TUI_RUNTIME_SPECIFIERS.map(
+                async (specifier) =>
+                    [specifier, new Set(Object.keys(await import(specifier)))] as const,
+            ),
+        );
+        return Object.fromEntries(entries);
+    }
+
+    test("every runtime specifier exists in the module it is imported from", async () => {
+        const exportSets = await loadExportSets();
+
+        const unresolved: string[] = [];
+        let checked = 0;
+
+        for (const file of compiledFiles(COMPILED_ROOT)) {
+            const source = readFileSync(file, "utf8");
+            for (const match of source.matchAll(IMPORT_PATTERN)) {
+                const moduleId = decodeURIComponent(match[2] ?? "");
+                const exports = exportSets[moduleId];
+                if (!exports) {
+                    // A runtime module id outside the rewritten set means the build
+                    // emitted something this guard does not know how to verify.
+                    // Failing is the only safe answer: skipping it silently is the
+                    // exact hole that let the `For` misroute ship.
+                    unresolved.push(
+                        `${file}: imports from unknown runtime module '${moduleId}' — ` +
+                            "add it to TUI_RUNTIME_SPECIFIERS so it can be verified",
+                    );
+                    continue;
+                }
+
+                for (const specifier of (match[1] ?? "").split(",")) {
+                    const importedName = specifier
+                        .trim()
+                        .split(/\s+as\s+/)[0]
+                        ?.trim();
+                    if (!importedName) continue;
+                    checked += 1;
+                    if (!exports.has(importedName)) {
+                        unresolved.push(
+                            `${file}: '${importedName}' is not exported by ${moduleId}`,
+                        );
+                    }
+                }
+            }
+        }
+
+        expect(checked).toBeGreaterThan(0);
+        expect(unresolved).toEqual([]);
+    });
+
+    test("every rewritten specifier resolves to a non-empty module", async () => {
+        // A specifier that stops resolving already fails loudly on its own: the
+        // dynamic import inside loadExportSets throws and takes the test with it.
+        // What that does NOT catch is a specifier that resolves to an empty module
+        // (a renamed or emptied subpath export), which would make the guard above
+        // report every import from it as unresolved for a misleading reason.
+        const exportSets = await loadExportSets();
+
+        const empty = TUI_RUNTIME_SPECIFIERS.filter(
+            (specifier) => (exportSets[specifier]?.size ?? 0) === 0,
+        );
+        expect(empty).toEqual([]);
+    });
+
+    test("TUI_RUNTIME_SPECIFIERS has no duplicates", () => {
+        // Object.fromEntries silently collapses duplicate keys, so a duplicated
+        // entry would shrink the export-set map without any other signal.
+        expect([...new Set(TUI_RUNTIME_SPECIFIERS)]).toEqual([...TUI_RUNTIME_SPECIFIERS]);
+    });
+
+    test("solid control-flow builtins are imported from solid-js, not @opentui/solid", async () => {
+        const openTuiExports = new Set(Object.keys(await import("@opentui/solid")));
+        const solidExports = new Set(Object.keys(await import("solid-js")));
+
+        // The builtins that belong to solid-js alone — the exact set the
+        // transform would otherwise misroute to @opentui/solid.
+        const misroutable = [...solidExports].filter((name) => !openTuiExports.has(name));
+
+        const violations: string[] = [];
+        for (const file of compiledFiles(COMPILED_ROOT)) {
+            const source = readFileSync(file, "utf8");
+            for (const match of source.matchAll(IMPORT_PATTERN)) {
+                if (decodeURIComponent(match[2] ?? "") !== "@opentui/solid") continue;
+                for (const specifier of (match[1] ?? "").split(",")) {
+                    const importedName = specifier
+                        .trim()
+                        .split(/\s+as\s+/)[0]
+                        ?.trim();
+                    if (importedName && misroutable.includes(importedName)) {
+                        violations.push(`${file}: '${importedName}' must come from solid-js`);
+                    }
+                }
+            }
+        }
+
+        expect(violations).toEqual([]);
+    });
+});


### PR DESCRIPTION
## Symptom

The sidebar and every `/ctx-*` command disappear. No crash, no stderr, nothing in `~/.local/share/opencode/log`. The server plugin is healthy the whole time — transforms run, RPC answers, the DB is fine. Only the TUI surface is gone.

I hit this on a daily driver after an OpenCode upgrade. It reproduces on clean `master`.

## Cause

`scripts/build-tui.ts` passes the Solid transform `moduleName: runtimeModuleId("@opentui/solid")`. The transform routes **every** import it emits through that single module — renderer helpers *and* control-flow builtins alike.

`@opentui/solid` only re-exports its own renderer helpers. The builtins live in `solid-js`. Measured against `@opentui/solid` 0.4.5:

| builtin | `@opentui/solid` | `solid-js` |
| --- | --- | --- |
| `For` | ✗ | ✓ |
| `Show` | ✗ | ✓ |
| `Index` | ✗ | ✓ |
| `Switch` | ✗ | ✓ |
| `Match` | ✗ | ✓ |
| `ErrorBoundary` | ✗ | ✓ |
| `Suspense` | ✗ | ✓ |
| `SuspenseList` | ✗ | ✓ |
| `Portal` | ✓ | ✗ |
| `Dynamic` | ✓ | ✗ |

`@opentui/solid` exposes 48 names and none of the eight control-flow builtins. `Portal` and `Dynamic` genuinely do belong to it.

The `<For>` at `src/tui/slots/sidebar-content.tsx:997` therefore compiles to:

```js
import { For as _$For } from "opentui:runtime-module:%40opentui%2Fsolid";
```

which throws at plugin load:

```
Export named 'For' not found in module 'opentui:runtime-module:%40opentui%2Fsolid'
```

OpenCode swallows errors thrown while loading a TUI plugin, so the plugin is dropped with no diagnostic. That silence is why the symptom looks like "the sidebar broke" rather than "the plugin failed to load".

This is latent on `master` — the committed `src/tui-compiled/slots/sidebar-content.tsx` carries the bad import today. It only becomes fatal once the host resolves that virtual module strictly.

## Fix

Redirect, after the transform, any specifier the OpenTUI runtime does not export to the `solid-js` runtime module.

The split is read from the **real export sets at build time** (`Object.keys(await import(...))`) rather than hardcoded, so it keeps working when OpenTUI changes what it re-exports — a hardcoded list would just relocate the bug to the next version bump.

A name exported by **neither** module now fails the build, instead of shipping a bundle that breaks the TUI silently.

The emitted imports are one specifier per statement, so the rewrite is a narrow line-level match rather than a general import parser.

## Verification

- Reproduced on clean `master`: committed bundle has the bad `For` import.
- After the fix all 24 `opentui:runtime-module:*` specifiers in the rebuilt bundle resolve against their target module's real exports.
- `build:tui` is reproducible — rebuilding leaves no drift.
- Confirmed live: sidebar and `/ctx-*` commands return.

Gates on this branch (clean `master` base): plugin **3532 pass / 0 fail**, `typecheck` 0 across all three packages, `check:tui-compiled` PASS.

## Regression test

`src/tui/tui-compiled-runtime-imports.test.ts` resolves every compiled specifier against the actual module export sets, and separately asserts no solid-js-only builtin is imported from `@opentui/solid`.

Red-checked both ways: **2/2 fail** with the pre-fix build script, **2/2 pass** after.

## Note on debugging this class

Worth knowing for anyone who hits a silent TUI drop: instrumenting the `tui` factory is not enough, because an empty log cannot distinguish "module never imported" from "factory never called". `src/tui/entry.mjs` runs before any TypeScript module loads and is the only place an import-time failure is observable. It also needs a synchronous writer — `src/shared/logger.ts` buffers and flushes on process exit, which is exactly the path a hard load failure skips.

Happy to split the test into its own commit or adjust the redirect's placement if you'd prefer it inside `compileTsx`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/magic-context/pr/282"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788680172&installation_model_id=22398&pr_number=282&repository=cortexkit%2Fmagic-context&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Fmagic-context%2Fpull%2F282&signature=645e3860c1b2250210bf60b4f243d7b9eae22c203d3809580802650ec5873918"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the TUI by routing Solid control‑flow builtins to `solid-js` instead of `@opentui/solid`. Restores the sidebar and `/ctx-*` commands, and prevents silent plugin drops.

- **Bug Fixes**
  - Reads export sets from `@opentui/solid` and `solid-js` at build time and rewrites single‑specifier `opentui:runtime-module:*` imports to `solid-js` when needed; fails the build if a name exists in neither module.
  - Recompiled sidebar so `<For>` imports from `solid-js`.
  - Adds shared `TUI_RUNTIME_SPECIFIERS` and `runtimeModuleId`; guard tests validate all compiled imports, reject unknown runtime module IDs, ensure modules are non‑empty and the list has no duplicates, and assert control‑flow builtins never import from `@opentui/solid`.

<sup>Written for commit 15371df9ad029a551c6eb6a35aa12520ca521f48. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/magic-context/pull/282?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR corrects generated TUI imports by routing Solid-only control-flow builtins to the host-provided `solid-js` runtime while retaining OpenTUI renderer helpers in `@opentui/solid`.
- Centralizes allowed TUI runtime specifiers and virtual-module ID generation.
- Resolves actual module export sets during TUI compilation and rejects unresolved generated imports.
- Regenerates the sidebar bundle with `For` imported from `solid-js`.
- Adds regression coverage validating every compiled runtime import against its target module.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/plugin/scripts/build-tui.ts | Adds export-aware post-transform routing so Solid-only builtins resolve from the correct host runtime module. |
| packages/plugin/src/shared/tui-runtime-specifiers.ts | Centralizes the runtime specifier allowlist and virtual-module ID construction for build and test consumers. |
| packages/plugin/src/tui-compiled/slots/sidebar-content.tsx | Updates the generated sidebar bundle so the transformed `For` builtin imports from `solid-js`. |
| packages/plugin/src/tui/tui-compiled-runtime-imports.test.ts | Validates compiled runtime imports against real module export sets and guards against future builtin misrouting. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    A[TSX source] --> B[Solid transform]
    B --> C{Generated name exported by OpenTUI Solid?}
    C -->|Yes| D[Keep @opentui/solid runtime import]
    C -->|No| E{Exported by solid-js?}
    E -->|Yes| F[Redirect to solid-js runtime import]
    E -->|No| G[Fail TUI build]
    D --> H[Compiled TUI]
    F --> H
    H --> I[Regression test validates runtime exports]
```
</details>

<sub>Reviews (5): Last reviewed commit: ["fix(tui): import Solid control-flow buil..."](https://github.com/cortexkit/magic-context/commit/15371df9ad029a551c6eb6a35aa12520ca521f48) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51095110)</sub>

<!-- /greptile_comment -->