### PR TITLE
fix(opencode): block internal workers from primary Task routing

### DIFF
--- a/packages/plugin/src/agent-registration-drift.test.ts
+++ b/packages/plugin/src/agent-registration-drift.test.ts
@@ -23,6 +23,8 @@ import {
 import {
     DREAMER_PRIMER_INVESTIGATOR_ALLOWED_TOOLS,
     DREAMER_RETROSPECTIVE_ALLOWED_TOOLS,
+    denyTaskRoutingToAgents,
+    denyTaskRoutingToCallerAgents,
     HISTORIAN_ALLOWED_TOOLS,
     SIDEKICK_ALLOWED_TOOLS,
     SMART_NOTE_COMPILER_ALLOWED_TOOLS,
@@ -70,6 +72,118 @@ describe("hidden-agent registration drift guard", () => {
                 SIDEKICK_AGENT,
             ].sort(),
         );
+    });
+
+    test("all Magic Context worker ids are denied through Task routing", () => {
+        const permission = denyTaskRoutingToAgents(
+            { task: { "*": "allow", "user-reviewer": "ask" } },
+            regs.map((reg) => reg.id),
+        ) as { task: Record<string, string> };
+
+        for (const reg of regs) {
+            expect(permission.task[reg.id]).toBe("deny");
+        }
+        expect(permission.task["user-reviewer"]).toBe("ask");
+    });
+
+    test("Task-routing denies apply only to Task callers", () => {
+        const subagentPermission = { "*": "deny", read: "allow" };
+        const agentConfigs = {
+            "custom-primary": { mode: "primary", permission: { task: { "*": "allow" } } },
+            "custom-all": { mode: "all", permission: { "*": "deny" } },
+            "custom-no-mode": { permission: subagentPermission },
+            "ordinary-subagent": { mode: "subagent", permission: subagentPermission },
+            general: { permission: subagentPermission },
+            explore: { permission: subagentPermission },
+        };
+        const configured = denyTaskRoutingToCallerAgents(
+            agentConfigs,
+            regs.map((reg) => reg.id),
+        );
+
+        for (const callerId of ["build", "plan", "custom-primary"]) {
+            const task = configured[callerId].permission as { task: Record<string, string> };
+            for (const reg of regs) {
+                expect(task.task[reg.id]).toBe("deny");
+            }
+        }
+        for (const subagentId of [
+            "custom-all",
+            "custom-no-mode",
+            "ordinary-subagent",
+            "general",
+            "explore",
+        ]) {
+            const permission = configured[subagentId].permission as Record<string, unknown>;
+            expect(permission).toEqual(
+                subagentId === "custom-all" ? { "*": "deny" } : subagentPermission,
+            );
+            expect(permission.task).toBeUndefined();
+        }
+
+        for (const [agentId, mode] of [
+            ["build", "all"],
+            ["build", "subagent"],
+            ["plan", "all"],
+            ["plan", "subagent"],
+        ] as const) {
+            const overridden = denyTaskRoutingToCallerAgents(
+                { [agentId]: { mode, permission: subagentPermission } },
+                regs.map((reg) => reg.id),
+            );
+            const permission = overridden[agentId].permission as Record<string, unknown>;
+            expect(permission).toEqual(subagentPermission);
+            expect(permission.task).toBeUndefined();
+        }
+    });
+
+    test("Task-routing denies preserve unrelated user permissions and win last", () => {
+        const userPermission = {
+            "*": "allow",
+            bash: { "git status*": "ask" },
+            task: {
+                [DREAMER_REVIEWER_AGENT]: "allow",
+                "*": "allow",
+                "custom-worker": "ask",
+            },
+        };
+        const permission = denyTaskRoutingToAgents(userPermission, [DREAMER_REVIEWER_AGENT]);
+
+        expect(permission).toEqual({
+            "*": "allow",
+            bash: { "git status*": "ask" },
+            task: {
+                "*": "allow",
+                "custom-worker": "ask",
+                [DREAMER_REVIEWER_AGENT]: "deny",
+            },
+        });
+        expect(userPermission.task[DREAMER_REVIEWER_AGENT]).toBe("allow");
+        expect(Object.keys(permission).at(-1)).toBe("task");
+        expect(Object.keys(permission.task).at(-1)).toBe(DREAMER_REVIEWER_AGENT);
+    });
+
+    test("Task-routing denies support OpenCode's whole-permission action form", () => {
+        expect(denyTaskRoutingToAgents("allow", [DREAMER_REVIEWER_AGENT])).toEqual({
+            "*": "allow",
+            task: { [DREAMER_REVIEWER_AGENT]: "deny" },
+        });
+    });
+
+    test("internal direct-prompt agent configuration remains a hidden subagent", () => {
+        const config = buildHiddenAgentConfig(
+            "reviewer prompt",
+            [],
+            4,
+            undefined,
+            DREAMER_REVIEWER_AGENT,
+            true,
+        );
+
+        expect(config.prompt).toBe("reviewer prompt");
+        expect(config.mode).toBe("subagent");
+        expect(config.hidden).toBe(true);
+        expect(config.permission).toEqual({ "*": "deny" });
     });
 
     test("classifier is a zero-tool locked pure transform", () => {

--- a/packages/plugin/src/agents/permissions.ts
+++ b/packages/plugin/src/agents/permissions.ts
@@ -108,6 +108,93 @@ export function buildAllowOnlyPermission(
     return permission;
 }
 
+type PermissionAction = "ask" | "allow" | "deny";
+
+function isPermissionAction(value: unknown): value is PermissionAction {
+    return value === "ask" || value === "allow" || value === "deny";
+}
+
+function isPermissionMap(value: unknown): value is Record<string, unknown> {
+    return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+/**
+ * Add final `permission.task` denies for Magic Context's internal workers.
+ *
+ * OpenCode accepts either a whole-permission action or a pattern map for
+ * `permission.task`; its evaluator uses the last matching rule. Normalize the
+ * whole-permission form, retain every unrelated user rule, then append our
+ * exact agent-id denies after both the user's task patterns and any `*` rule.
+ */
+export function denyTaskRoutingToAgents(
+    permission: unknown,
+    internalAgentIds: readonly string[],
+): Record<string, unknown> {
+    const configured = isPermissionAction(permission)
+        ? { "*": permission }
+        : isPermissionMap(permission)
+          ? permission
+          : {};
+    const { task, ...otherPermissions } = configured;
+    const configuredTask = isPermissionAction(task)
+        ? { "*": task }
+        : isPermissionMap(task)
+          ? task
+          : {};
+    const internalAgentIdSet = new Set(internalAgentIds);
+    const retainedTask = Object.fromEntries(
+        Object.entries(configuredTask).filter(([agentId]) => !internalAgentIdSet.has(agentId)),
+    );
+
+    return {
+        ...otherPermissions,
+        task: {
+            ...retainedTask,
+            ...Object.fromEntries(internalAgentIds.map((agentId) => [agentId, "deny"])),
+        },
+    };
+}
+
+const BUILTIN_TASK_CALLER_IDS = ["build", "plan"] as const;
+
+function isTaskRoutingCaller(agentId: string, config: Record<string, unknown>): boolean {
+    const mode = config.mode;
+    // OpenCode compatibility:
+    // Only strictly-primary callers receive explicit Task routing rules.
+    // Agents that may execute as Task children are intentionally left untouched,
+    // because explicit task permissions can alter OpenCode's default anti-nesting
+    // behavior in the currently supported permission model.
+    if (mode === "primary") return true;
+    if (mode === "subagent" || mode === "all") return false;
+    return agentId === "build" || agentId === "plan";
+}
+
+/**
+ * Apply Task routing denies only to agents that can act as Task callers.
+ *
+ * A top-level permission rule is merged into every OpenCode agent. Adding one
+ * there would suppress the Task tool's default deny for ordinary subagents, so
+ * seed only the built-in interactive callers and configured primary agents.
+ */
+export function denyTaskRoutingToCallerAgents(
+    agentConfigs: Record<string, Record<string, unknown>>,
+    internalAgentIds: readonly string[],
+): Record<string, Record<string, unknown>> {
+    const result = { ...agentConfigs };
+    const candidateIds = new Set([...BUILTIN_TASK_CALLER_IDS, ...Object.keys(agentConfigs)]);
+
+    for (const agentId of candidateIds) {
+        const agentConfig = agentConfigs[agentId] ?? {};
+        if (!isTaskRoutingCaller(agentId, agentConfig)) continue;
+        result[agentId] = {
+            ...agentConfig,
+            permission: denyTaskRoutingToAgents(agentConfig.permission, internalAgentIds),
+        };
+    }
+
+    return result;
+}
+
 /**
  * Tools the historian + historian-editor + compressor agents need.
  *

--- a/packages/plugin/src/features/magic-context/user-memory/review-user-memories.test.ts
+++ b/packages/plugin/src/features/magic-context/user-memory/review-user-memories.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, mock, test } from "bun:test";
 
+import { DREAMER_REVIEWER_AGENT } from "../../../agents/dreamer";
 import { Database } from "../../../shared/sqlite";
 import { runMigrations } from "../migrations";
 import { initializeDatabase } from "../storage-db";
@@ -20,12 +21,13 @@ describe("reviewUserMemories", () => {
             { content: "User prefers concise updates", sessionId: "s1" },
         ]);
         const deleted: string[] = [];
+        const prompt = mock(async () => {
+            throw new Error("model unavailable");
+        });
         const client = {
             session: {
                 create: mock(async () => ({ id: "child-user-memories" })),
-                prompt: mock(async () => {
-                    throw new Error("model unavailable");
-                }),
+                prompt,
                 delete: mock(async ({ path }: { path: { id: string } }) => {
                     deleted.push(path.id);
                     return {};
@@ -46,6 +48,12 @@ describe("reviewUserMemories", () => {
             }),
         ).rejects.toThrow("model unavailable");
 
+        expect(
+            prompt.mock.calls.some(([input]) => {
+                const body = (input as { body?: { agent?: string } }).body;
+                return body?.agent === DREAMER_REVIEWER_AGENT;
+            }),
+        ).toBe(true);
         expect(deleted).toEqual(["child-user-memories"]);
         db.close();
     });

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -5,6 +5,7 @@ import {
     buildHiddenAgentRegistrations,
 } from "./agents/hidden-agent-registrations";
 import { withContentLanguageDirective } from "./agents/language-directive";
+import { denyTaskRoutingToCallerAgents } from "./agents/permissions";
 import { loadPluginConfigDetailed } from "./config";
 import { isCompactionEnabled, isDreamerRunnable } from "./config/agent-disable";
 import { migrateMagicContextConfigLocations } from "./config/migrate-config-location";
@@ -745,6 +746,8 @@ const server: Plugin = async (ctx) => {
                 });
 
                 const agentConfig = { ...(config.agent ?? {}) } as NonNullable<typeof config.agent>;
+                const agentConfigRecord = agentConfig as Record<string, Record<string, unknown>>;
+                const internalAgentIds = registrations.map((registration) => registration.id);
                 for (const reg of registrations) {
                     if (typeof reg.prompt !== "string" || reg.prompt.length === 0) {
                         log(
@@ -752,7 +755,7 @@ const server: Plugin = async (ctx) => {
                         );
                         continue;
                     }
-                    agentConfig[reg.id] = buildHiddenAgentConfig(
+                    agentConfigRecord[reg.id] = buildHiddenAgentConfig(
                         reg.prompt,
                         reg.allowedTools,
                         reg.maxSteps,
@@ -761,7 +764,11 @@ const server: Plugin = async (ctx) => {
                         reg.lockPermissions === true,
                     );
                 }
-                config.agent = agentConfig;
+                const callerAgentConfig = denyTaskRoutingToCallerAgents(
+                    agentConfigRecord,
+                    internalAgentIds,
+                );
+                config.agent = callerAgentConfig as NonNullable<typeof config.agent>;
             } catch (error) {
                 // A failure registering commands/agents must NEVER fail the whole
                 // plugin load — that would also disable the transform/compaction


### PR DESCRIPTION
## Summary

Fixes #285.

Magic Context has a few internal workers that are registered as hidden subagents. The problem is that `hidden: true` only keeps them out of the normal agent picker — it doesn't stop OpenCode from selecting them through Task routing.

That can lead to something like `dreamer-reviewer` being picked as a normal code-review subagent, even though it's really meant to be called internally by Magic Context.

This patch adds Task routing denies for Magic Context's internal worker agents.

For now, I only apply those denies to callers that are strictly primary: the built-in `build` and `plan` agents, plus agents explicitly configured with `mode: "primary"`.

Existing user Task permissions are kept intact. If there is already a rule for one of the internal workers, the patch removes that exact rule and adds the final `"deny"` after the existing Task rules, so it still wins with OpenCode's last-match-wins behavior.

I also intentionally avoided adding anything to top-level `config.permission`.

## Why only primary callers?

I originally looked at applying this more broadly, but agents using `mode: "all"` or `mode: "subagent"` may also run as Task children.

With the OpenCode permission behavior currently used by the plugin, adding an explicit Task rule to those agents can change the default anti-nesting behavior OpenCode applies to Task children.

So this patch leaves `mode: "all"`, `mode: "subagent"`, no-mode custom agents, `general`, and `explore` alone. The same applies if `build` or `plan` has been explicitly changed to a non-primary mode.

That does leave a small known gap for agents that can act as both primary and subagent, but I thought it was safer to keep this fix narrow rather than change Task-child behavior as a side effect.

Magic Context's own internal dispatch is unchanged. Internal workers such as `dreamer-reviewer` are still called directly with `session.prompt({ agent: ... })`; these new rules only affect normal Task delegation.

## Testing

I added regression coverage around the routing boundary, existing permission preservation, rule ordering, and the direct reviewer dispatch path.

After rebasing onto the latest `master`:

* permission / registration tests: 53 passed
* reviewer dispatch test: 1 passed
* plugin typecheck: passed
* changed-file Biome check: passed
* `git diff --check`: passed
* full plugin suite: 3605 passed, 6 failed

Five of those full-suite failures reproduce on clean master. The remaining compiled-TUI assertion appears intermittent and passed three focused reruns after the rebase.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/magic-context/pr/287"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788850904&installation_model_id=22398&pr_number=287&repository=cortexkit%2Fmagic-context&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Fmagic-context%2Fpull%2F287&signature=7e1f79bd6a9bef4ec6491f7928cfc812442a8cf9e7d772bf8aa47550d04825ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Block OpenCode from routing primary Task calls to Magic Context’s internal workers by appending explicit `deny` rules to `permission.task`. Fixes #285.

- **Bug Fixes**
  - Append final `permission.task` denies for internal worker IDs, preserving all unrelated user rules and supporting both action and map forms (last-match wins).
  - Apply denies only to primary callers: built-in `build`, `plan`, and agents with `mode: "primary"`; leave `general`, `explore`, `mode: "all"`, `mode: "subagent"`, and no-mode agents unchanged.
  - Do not modify top-level `config.permission`; internal workers stay hidden subagents and are still invoked via `session.prompt({ agent: ... })`.

<sup>Written for commit 2a83a4e647b6dc213edc3f381dd3c2e2d87f58b0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/magic-context/pull/287?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR prevents strictly primary OpenCode agents from selecting Magic Context’s hidden internal workers through normal Task delegation while preserving direct internal dispatch.
- Adds permission helpers that append final per-worker Task deny rules while retaining unrelated user permissions.
- Applies the rules to `build`, `plan`, and custom agents explicitly configured with `mode: "primary"`.
- Adds regression coverage for routing scope, permission ordering and preservation, whole-permission actions, hidden-agent configuration, and direct reviewer dispatch.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete blocking or independently actionable non-blocking defect identified.

The changed permission transformation preserves unrelated rules, places exact internal-worker denies last for strictly primary callers, and leaves the intentionally excluded dual-role and subagent configurations unchanged.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/plugin/src/agents/permissions.ts | Adds narrowly scoped Task-routing permission normalization, caller classification, and final internal-worker deny rules without an accepted defect. |
| packages/plugin/src/index.ts | Integrates internal-worker deny generation after hidden-agent registration and assigns the transformed agent configuration. |
| packages/plugin/src/agent-registration-drift.test.ts | Adds regression tests for caller scope, worker coverage, permission preservation, ordering, action normalization, and hidden-agent configuration. |
| packages/plugin/src/features/magic-context/user-memory/review-user-memories.test.ts | Verifies that reviewer work continues to use direct agent-specific session prompting. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[OpenCode agent configuration] --> B{Caller classification}
    B -->|build or plan with no non-primary override| C[Strictly primary caller]
    B -->|mode: primary| C
    B -->|mode: all, subagent, or excluded no-mode agent| D[Leave permissions unchanged]
    C --> E[Preserve existing permission rules]
    E --> F[Remove exact internal-worker rules]
    F --> G[Append final deny for every internal worker]
    G --> H[Normal Task routing cannot select internal workers]
    I[Magic Context direct session.prompt dispatch] --> J[Hidden internal worker remains callable internally]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(opencode): block internal workers fr..."](https://github.com/cortexkit/magic-context/commit/2a83a4e647b6dc213edc3f381dd3c2e2d87f58b0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51547420)</sub>

<!-- /greptile_comment -->