### PR TITLE
perf: lazy-load ai-tokenizer

### DIFF
--- a/packages/plugin/src/hooks/magic-context/read-session-formatting.ts
+++ b/packages/plugin/src/hooks/magic-context/read-session-formatting.ts
@@ -1,3 +1,6 @@
+import { createRequire } from "node:module";
+import type TokenizerType from "ai-tokenizer";
+import type * as ClaudeEncodingType from "ai-tokenizer/encoding/claude";
 import { COMMIT_VERB_PATTERN, createCommitHashExtractPattern } from "../../shared/commit-detection";
 import { OMO_INTERNAL_INITIATOR_MARKER } from "../../shared/internal-initiator-marker";
 import { isSystemDirective, removeSystemReminders } from "../../shared/system-directive";
@@ -109,17 +112,28 @@ function truncateArg(value: string, maxLen = 60): string {
     return `${value.slice(0, maxLen)}…`;
 }
 
-// Real Claude tokenizer (ai-tokenizer with Claude encoding). Static ESM
-// import — ai-tokenizer is a hard runtime dependency and is used on every
-// transform pass, so there's no reason to lazy-load it. The previous
-// dynamic `eval("require")` pattern silently failed in Bun's ESM runtime
-// and fell back to `Math.ceil(text.length / 3.5)`, which over-counted
-// base64 thinking signatures and under-counted JSON tool content, making
-// the sidebar's "Tool Defs + Overhead" residual wrong on long sessions.
-import Tokenizer from "ai-tokenizer";
-import * as claudeEncoding from "ai-tokenizer/encoding/claude";
+// Keep these specifiers non-literal so Bun does not include the Claude
+// tokenizer vocabulary in the eager plugin bundle. Unlike the prior
+// `eval("require")` fallback, createRequire works in Bun's ESM runtime.
+const lazyRequire = createRequire(import.meta.url);
+let cachedTokenizer: InstanceType<typeof TokenizerType> | null = null;
 
-const tokenizer = new Tokenizer(claudeEncoding);
+function getTokenizer(): InstanceType<typeof TokenizerType> {
+    if (cachedTokenizer) return cachedTokenizer;
+
+    const tokenizerModule = lazyRequire("ai-" + "tokenizer") as {
+        default?: typeof TokenizerType;
+        Tokenizer?: typeof TokenizerType;
+    };
+    const Tokenizer = tokenizerModule.default ?? tokenizerModule.Tokenizer;
+    if (!Tokenizer) throw new Error("ai-tokenizer does not export Tokenizer");
+
+    const claudeEncoding = lazyRequire(
+        "ai-tokenizer/encoding/" + "claude",
+    ) as typeof ClaudeEncodingType;
+    cachedTokenizer = new Tokenizer(claudeEncoding);
+    return cachedTokenizer;
+}
 
 export function estimateTokens(text: string): number {
     if (!text) return 0;
@@ -132,7 +146,7 @@ export function estimateTokens(text: string): number {
     // vector. Token counts for content WITHOUT special-token substrings are
     // identical; for content WITH them we now count the literal bytes (correct,
     // since the wire carries the literal string, not a real control token).
-    return tokenizer.encode(text, "all").length;
+    return getTokenizer().encode(text, "all").length;
 }
 
 export function normalizeText(text: string): string {


### PR DESCRIPTION
## Summary

Lazy-load ai-tokenizer on the first estimateTokens() call instead of importing it during plugin startup.

As described in #286, the static imports caused the Claude tokenizer vocabulary to be included in the eagerly loaded bundle even when token estimation had not been used yet.

## This change:

loads the tokenizer with createRequire(import.meta.url) only when needed
caches the tokenizer instance after the first load
preserves the existing synchronous estimateTokens() API and encode(text, "all") behavior
Bundle impact

For the Pi plugin, the eagerly imported shared chunk decreased from:

4,634,679 B → 2,136,654 B

ai-tokenizer inputs in the Bun metafile decreased from:

4 inputs / 2,413,204 B → 0 inputs / 0 B

The tokenizer is also no longer included in the OpenCode eager bundle.

## Validation
estimate-tokens.test.ts: 4/4 passing
plugin typecheck: passing
Pi plugin typecheck: passing
plugin build: passing
Pi plugin build: passing
verified via Bun metafile that ai-tokenizer is no longer part of the eager bundle
verified runtime resolution from a packed Pi installation
confirmed token counts remain equivalent to the existing Claude tokenizer implementation, including special-token-like input

---

Thanks to the author of #286 for the detailed investigation, proposed approach, and benchmark. This PR implements and validates that approach against the current master.

Fixes #286

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/magic-context/pr/288"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788854561&installation_model_id=22398&pr_number=288&repository=cortexkit%2Fmagic-context&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Fmagic-context%2Fpull%2F288&signature=863c5c9b8753442cd4b5634211fd17cc71aa8b59051483f28363bdeefff07986"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lazy-loads `ai-tokenizer` on first estimateTokens() call to keep the Claude vocabulary out of the eager bundle and cut startup size. Token counts and the synchronous API remain unchanged.

- **Refactors**
  - Replace static import with `createRequire(import.meta.url)` lazy load and cache the tokenizer after first use.
  - Preserve estimateTokens() sync API and encode(text, "all") behavior.
  - Bundle impact: Pi shared chunk 4,634,679 B → 2,136,654 B; Bun metafile `ai-tokenizer` inputs 4 (2,413,204 B) → 0.

<sup>Written for commit d98923179bb4a62c74bdb93eb90b00ceb2c9c62c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/magic-context/pull/288?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR defers loading `ai-tokenizer` until the first non-empty token estimate while retaining the synchronous API and caching the initialized tokenizer.

- Replaces eager tokenizer imports with `createRequire(import.meta.url)` calls whose non-literal specifiers avoid eager Bun bundling.
- Supports either default or named `Tokenizer` exports.
- Reuses the initialized Claude tokenizer for subsequent estimates.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable correctness, compatibility, or security failures identified.

The affected packages retain `ai-tokenizer` as a runtime dependency, target Node-compatible environments, and preserve the existing synchronous encoding behavior while changing only when tokenizer initialization occurs.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/plugin/src/hooks/magic-context/read-session-formatting.ts | Lazily resolves and caches the Claude tokenizer without changing token-estimation semantics; no actionable defect was established. |

</details>

<sub>Reviews (1): Last reviewed commit: ["perf: lazy-load ai-tokenizer"](https://github.com/cortexkit/magic-context/commit/d98923179bb4a62c74bdb93eb90b00ceb2c9c62c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51552175)</sub>

<!-- /greptile_comment -->