### PR TITLE
fix(storage): honour MAGIC_CONTEXT_TEST_DATA_DIR in the shared storage resolver

### DIFF
--- a/packages/plugin/src/features/magic-context/storage-db.ts
+++ b/packages/plugin/src/features/magic-context/storage-db.ts
@@ -158,27 +158,13 @@ export function resolveDatabasePath(dbPathOverride?: string): { dbDir: string; d
     if (dbPathOverride) {
         return { dbDir: dirname(dbPathOverride), dbPath: dbPathOverride };
     }
-    // Test-isolation guard. Under the test runner the preload
-    // (bunfig.toml `[test] preload`) sets MAGIC_CONTEXT_TEST_DATA_DIR to a
-    // throwaway temp dir AND XDG_DATA_HOME to the same dir. Tests that manage
-    // their OWN XDG_DATA_HOME (per-test temp dirs) keep working — we honor XDG
-    // below via getMagicContextStorageDir(). The guard fires ONLY when
-    // XDG_DATA_HOME is UNSET: that is the dangerous window, because
-    // getMagicContextStorageDir() would otherwise fall back to the REAL
-    // ~/.local/share and a bare openDatabase() would run migrations on the
-    // user's production DB. Some tests delete XDG_DATA_HOME to exercise
-    // path-fallback behavior (2026-06-01 incident: a dormant test migrated the
-    // live DB to v26 and fail-closed every running v25 binary); in that window
-    // we resolve into the dedicated test dir instead of the real path. No test
-    // mutates MAGIC_CONTEXT_TEST_DATA_DIR, so the guard cannot be defeated. It
-    // is never set in production.
-    const testDataDir = process.env.MAGIC_CONTEXT_TEST_DATA_DIR;
-    if (testDataDir && !process.env.XDG_DATA_HOME) {
-        const dbDir = join(testDataDir, "cortexkit", "magic-context");
-        return { dbDir, dbPath: join(dbDir, "context.db") };
-    }
-    // CWD-INDEPENDENT TEST BACKSTOP. The MAGIC_CONTEXT_TEST_DATA_DIR / XDG guard
-    // above only fires when the bunfig `[test] preload` ran — which depends on
+    // Test-isolation guard: MAGIC_CONTEXT_TEST_DATA_DIR is honored inside
+    // getMagicContextStorageDir() below (see its doc comment), so it covers
+    // this resolver and every other caller alike. The NODE_ENV backstop below
+    // stays here: it needs a memoized throwaway dir, which a pure path helper
+    // has no business creating.
+    // CWD-INDEPENDENT TEST BACKSTOP. The MAGIC_CONTEXT_TEST_DATA_DIR guard only
+    // fires when the bunfig `[test] preload` ran — which depends on
     // `bun test`'s CWD having a bunfig with `[test] preload`. A `bun test` from a
     // dir WITHOUT that wiring (monorepo root, a package missing its bunfig, or a
     // brand-new package) recursively runs every *.test.ts with NO preload, so a
@@ -198,7 +184,11 @@ export function resolveDatabasePath(dbPathOverride?: string): { dbDir: string; d
     // per-test temp dir, e.g. to exercise path fallbacks or share a DB across
     // helper calls), getMagicContextStorageDir() already points inside that
     // controlled dir — honor it, do not override.
-    if (process.env.NODE_ENV === "test" && !process.env.XDG_DATA_HOME) {
+    if (
+        process.env.NODE_ENV === "test" &&
+        !process.env.XDG_DATA_HOME &&
+        !process.env.MAGIC_CONTEXT_TEST_DATA_DIR
+    ) {
         // Memoized per-process so repeated openDatabase() calls in the same
         // unisolated test resolve to the SAME path (openDatabase caches by path;
         // a fresh temp dir per call would defeat the cache and hand back

--- a/packages/plugin/src/features/magic-context/storage-db.ts
+++ b/packages/plugin/src/features/magic-context/storage-db.ts
@@ -5,13 +5,11 @@ import {
     type Dirent,
     existsSync,
     mkdirSync,
-    mkdtempSync,
     readdirSync,
     readFileSync,
     statSync,
     unlinkSync,
 } from "node:fs";
-import { tmpdir } from "node:os";
 import { basename, dirname, join } from "node:path";
 import { bootQuietRemainingMs, scheduleAfterBootQuiet } from "../../plugin/boot-quiet";
 import {
@@ -158,67 +156,12 @@ export function resolveDatabasePath(dbPathOverride?: string): { dbDir: string; d
     if (dbPathOverride) {
         return { dbDir: dirname(dbPathOverride), dbPath: dbPathOverride };
     }
-    // Test-isolation guard: MAGIC_CONTEXT_TEST_DATA_DIR is honored inside
-    // getMagicContextStorageDir() below (see its doc comment), so it covers
-    // this resolver and every other caller alike. The NODE_ENV backstop below
-    // stays here: it needs a memoized throwaway dir, which a pure path helper
-    // has no business creating.
-    // CWD-INDEPENDENT TEST BACKSTOP. The MAGIC_CONTEXT_TEST_DATA_DIR guard only
-    // fires when the bunfig `[test] preload` ran — which depends on
-    // `bun test`'s CWD having a bunfig with `[test] preload`. A `bun test` from a
-    // dir WITHOUT that wiring (monorepo root, a package missing its bunfig, or a
-    // brand-new package) recursively runs every *.test.ts with NO preload, so a
-    // bare openDatabase() would resolve to the user's REAL shared DB and run
-    // migrations on it. That is exactly how the live DB was migrated to v41 by a
-    // worktree whose LATEST was 41 (a re-run of the 2026-06-01 v26 incident).
-    //
-    // Bun sets NODE_ENV=test for EVERY `bun test` regardless of CWD/bunfig (and
-    // it is never "test" in the plugin runtime — production never sets it). So if
-    // we are under the test runner with neither the test data dir nor an explicit
-    // override, we MUST NOT touch real storage: redirect into a throwaway temp dir
-    // so the live DB is physically unreachable. This makes it structurally
-    // impossible for ANY test, from ANY CWD, to read or migrate production data.
-    // Fire ONLY when XDG_DATA_HOME is unset: that is the dangerous window where
-    // getMagicContextStorageDir() below would otherwise resolve to the REAL
-    // ~/.local/share shared DB. When a test sets its own XDG_DATA_HOME (a
-    // per-test temp dir, e.g. to exercise path fallbacks or share a DB across
-    // helper calls), getMagicContextStorageDir() already points inside that
-    // controlled dir — honor it, do not override.
-    if (
-        process.env.NODE_ENV === "test" &&
-        !process.env.XDG_DATA_HOME &&
-        !process.env.MAGIC_CONTEXT_TEST_DATA_DIR
-    ) {
-        // Memoized per-process so repeated openDatabase() calls in the same
-        // unisolated test resolve to the SAME path (openDatabase caches by path;
-        // a fresh temp dir per call would defeat the cache and hand back
-        // different DB handles).
-        const dbDir = getTestBackstopDbDir();
-        if (!testBackstopWarned) {
-            testBackstopWarned = true;
-            log(
-                "[magic-context] TEST BACKSTOP: NODE_ENV=test with no MAGIC_CONTEXT_TEST_DATA_DIR " +
-                    `— redirecting DB to a throwaway temp dir (${dbDir}) so no test can touch the ` +
-                    "user's real shared database. Wire `[test] preload` in this package's bunfig.toml.",
-            );
-        }
-        return { dbDir, dbPath: join(dbDir, "context.db") };
-    }
+    // Test-isolation guards (MAGIC_CONTEXT_TEST_DATA_DIR + the CWD-independent
+    // NODE_ENV backstop) both live in getMagicContextStorageDir(), so this
+    // resolver and every direct caller of that helper are covered by one
+    // implementation. See its doc comment for the incident history.
     const dbDir = getMagicContextStorageDir();
     return { dbDir, dbPath: join(dbDir, "context.db") };
-}
-
-let testBackstopDbDir: string | null = null;
-let testBackstopWarned = false;
-function getTestBackstopDbDir(): string {
-    if (!testBackstopDbDir) {
-        testBackstopDbDir = join(
-            mkdtempSync(join(tmpdir(), "mc-test-db-backstop-")),
-            "cortexkit",
-            "magic-context",
-        );
-    }
-    return testBackstopDbDir;
 }
 
 export function getDatabasePath(db: Database): string | null {

--- a/packages/plugin/src/shared/data-path.test.ts
+++ b/packages/plugin/src/shared/data-path.test.ts
@@ -93,14 +93,38 @@ describe("data-path", () => {
         // Cross-harness shared path: both OpenCode and Pi plugins read/write here,
         // unlike the legacy opencode/storage/plugin/magic-context location which
         // was OpenCode-specific. See ARCHITECTURE_DECISIONS memory for rationale.
-        // Production shape, so the test-isolation dir set by test-preload.ts is
+        // Production shape, so both test-isolation guards (the preload's data
+        // dir and the NODE_ENV backstop bun sets for every `bun test`) are
         // lifted for the duration of this assertion.
         const savedTestDir = process.env.MAGIC_CONTEXT_TEST_DATA_DIR;
+        const savedNodeEnv = process.env.NODE_ENV;
         delete process.env.MAGIC_CONTEXT_TEST_DATA_DIR;
+        delete process.env.NODE_ENV;
         try {
             expect(getMagicContextStorageDir()).toBe(
                 path.join(os.homedir(), ".local", "share", "cortexkit", "magic-context"),
             );
+        } finally {
+            if (savedTestDir !== undefined) process.env.MAGIC_CONTEXT_TEST_DATA_DIR = savedTestDir;
+            if (savedNodeEnv !== undefined) process.env.NODE_ENV = savedNodeEnv;
+        }
+    });
+
+    test("getMagicContextStorageDir backstops to a temp dir under NODE_ENV=test with no guard set", () => {
+        // CWD-independent backstop: a `bun test` from a dir whose bunfig has no
+        // `[test] preload` runs every suite with neither guard env var set. The
+        // DB resolver used to own this branch, so direct callers of this helper
+        // (the CLI doctors' own PRAGMA integrity_check) still reached the real
+        // shared DB. Memoized, so repeated calls must agree — openDatabase()
+        // caches by path.
+        const savedTestDir = process.env.MAGIC_CONTEXT_TEST_DATA_DIR;
+        delete process.env.MAGIC_CONTEXT_TEST_DATA_DIR;
+        process.env.NODE_ENV = "test";
+        try {
+            const resolved = getMagicContextStorageDir();
+            expect(resolved).not.toContain(path.join(os.homedir(), ".local", "share"));
+            expect(resolved.endsWith(path.join("cortexkit", "magic-context"))).toBe(true);
+            expect(getMagicContextStorageDir()).toBe(resolved);
         } finally {
             if (savedTestDir !== undefined) process.env.MAGIC_CONTEXT_TEST_DATA_DIR = savedTestDir;
         }

--- a/packages/plugin/src/shared/data-path.test.ts
+++ b/packages/plugin/src/shared/data-path.test.ts
@@ -21,6 +21,7 @@ const savedEnv = {
     LOCALAPPDATA: process.env.LOCALAPPDATA,
     MAGIC_CONTEXT_LOG_PATH: process.env.MAGIC_CONTEXT_LOG_PATH,
     MAGIC_CONTEXT_TEST_DATA_DIR: process.env.MAGIC_CONTEXT_TEST_DATA_DIR,
+    NODE_ENV: process.env.NODE_ENV,
 };
 
 describe("data-path", () => {
@@ -37,17 +38,14 @@ describe("data-path", () => {
     });
 
     afterEach(() => {
-        if (savedEnv.XDG_CACHE_HOME !== undefined)
-            process.env.XDG_CACHE_HOME = savedEnv.XDG_CACHE_HOME;
-        if (savedEnv.XDG_DATA_HOME !== undefined)
-            process.env.XDG_DATA_HOME = savedEnv.XDG_DATA_HOME;
-        if (savedEnv.LOCALAPPDATA !== undefined) process.env.LOCALAPPDATA = savedEnv.LOCALAPPDATA;
-        if (savedEnv.MAGIC_CONTEXT_LOG_PATH !== undefined)
-            process.env.MAGIC_CONTEXT_LOG_PATH = savedEnv.MAGIC_CONTEXT_LOG_PATH;
-        else delete process.env.MAGIC_CONTEXT_LOG_PATH;
-        if (savedEnv.MAGIC_CONTEXT_TEST_DATA_DIR !== undefined)
-            process.env.MAGIC_CONTEXT_TEST_DATA_DIR = savedEnv.MAGIC_CONTEXT_TEST_DATA_DIR;
-        else delete process.env.MAGIC_CONTEXT_TEST_DATA_DIR;
+        // Restore-or-delete every var this suite touches. Several tests lift a
+        // guard (NODE_ENV, MAGIC_CONTEXT_TEST_DATA_DIR) to assert production
+        // shape, so a restore that skips the unset case would leak state into
+        // the next test and make results order-dependent.
+        for (const [key, value] of Object.entries(savedEnv)) {
+            if (value !== undefined) process.env[key] = value;
+            else delete process.env[key];
+        }
     });
 
     test("getCacheDir falls back to <homedir>/.cache when XDG_CACHE_HOME is unset (all platforms)", () => {

--- a/packages/plugin/src/shared/data-path.test.ts
+++ b/packages/plugin/src/shared/data-path.test.ts
@@ -20,6 +20,7 @@ const savedEnv = {
     XDG_DATA_HOME: process.env.XDG_DATA_HOME,
     LOCALAPPDATA: process.env.LOCALAPPDATA,
     MAGIC_CONTEXT_LOG_PATH: process.env.MAGIC_CONTEXT_LOG_PATH,
+    MAGIC_CONTEXT_TEST_DATA_DIR: process.env.MAGIC_CONTEXT_TEST_DATA_DIR,
 };
 
 describe("data-path", () => {
@@ -44,6 +45,9 @@ describe("data-path", () => {
         if (savedEnv.MAGIC_CONTEXT_LOG_PATH !== undefined)
             process.env.MAGIC_CONTEXT_LOG_PATH = savedEnv.MAGIC_CONTEXT_LOG_PATH;
         else delete process.env.MAGIC_CONTEXT_LOG_PATH;
+        if (savedEnv.MAGIC_CONTEXT_TEST_DATA_DIR !== undefined)
+            process.env.MAGIC_CONTEXT_TEST_DATA_DIR = savedEnv.MAGIC_CONTEXT_TEST_DATA_DIR;
+        else delete process.env.MAGIC_CONTEXT_TEST_DATA_DIR;
     });
 
     test("getCacheDir falls back to <homedir>/.cache when XDG_CACHE_HOME is unset (all platforms)", () => {
@@ -89,8 +93,38 @@ describe("data-path", () => {
         // Cross-harness shared path: both OpenCode and Pi plugins read/write here,
         // unlike the legacy opencode/storage/plugin/magic-context location which
         // was OpenCode-specific. See ARCHITECTURE_DECISIONS memory for rationale.
+        // Production shape, so the test-isolation dir set by test-preload.ts is
+        // lifted for the duration of this assertion.
+        const savedTestDir = process.env.MAGIC_CONTEXT_TEST_DATA_DIR;
+        delete process.env.MAGIC_CONTEXT_TEST_DATA_DIR;
+        try {
+            expect(getMagicContextStorageDir()).toBe(
+                path.join(os.homedir(), ".local", "share", "cortexkit", "magic-context"),
+            );
+        } finally {
+            if (savedTestDir !== undefined) process.env.MAGIC_CONTEXT_TEST_DATA_DIR = savedTestDir;
+        }
+    });
+
+    test("getMagicContextStorageDir honors MAGIC_CONTEXT_TEST_DATA_DIR when XDG_DATA_HOME is unset", () => {
+        // The hole this closes: a test that deletes XDG_DATA_HOME to exercise
+        // path fallbacks used to resolve to the user's REAL shared storage,
+        // because bun caches os.homedir() and a mutated process.env.HOME cannot
+        // move getDataDir(). Callers that build their own context.db path (the
+        // CLI doctors) then ran integrity checks against production data.
+        process.env.MAGIC_CONTEXT_TEST_DATA_DIR = "/tmp/mc-test-isolation";
         expect(getMagicContextStorageDir()).toBe(
-            path.join(os.homedir(), ".local", "share", "cortexkit", "magic-context"),
+            path.join("/tmp/mc-test-isolation", "cortexkit", "magic-context"),
+        );
+    });
+
+    test("getMagicContextStorageDir prefers XDG_DATA_HOME over MAGIC_CONTEXT_TEST_DATA_DIR", () => {
+        // A test managing its own per-test data home is already controlled, and
+        // several suites depend on that dir being honored.
+        process.env.MAGIC_CONTEXT_TEST_DATA_DIR = "/tmp/mc-test-isolation";
+        process.env.XDG_DATA_HOME = "/tmp/custom-data";
+        expect(getMagicContextStorageDir()).toBe(
+            path.join("/tmp/custom-data", "cortexkit", "magic-context"),
         );
     });
 

--- a/packages/plugin/src/shared/data-path.ts
+++ b/packages/plugin/src/shared/data-path.ts
@@ -167,9 +167,27 @@ export function getOpenCodeStorageDir(): string {
  *   - Future cross-harness session migration
  *
  * Layout: <XDG_DATA_HOME>/cortexkit/magic-context/
+ *
+ * TEST-ISOLATION GUARD. `openDatabase()` has been guarded in
+ * `resolveDatabasePath()` since the 2026-06-01 (v26) and 2026-06-19 (v41)
+ * incidents, in which unisolated tests migrated the user's REAL shared DB.
+ * Every OTHER caller bypassed that guard — notably the CLI doctors, which
+ * build `join(getMagicContextStorageDir(), "context.db")` themselves and run
+ * `PRAGMA integrity_check` against it. A test that deletes XDG_DATA_HOME to
+ * exercise path fallbacks cannot restore isolation by setting
+ * `process.env.HOME`: bun caches `os.homedir()` at startup, so `getDataDir()`
+ * still resolves to the real home. Honoring MAGIC_CONTEXT_TEST_DATA_DIR here —
+ * set by `packages/plugin/test-preload.ts` and mutated by no test — makes the
+ * preload's "cannot be defeated" guarantee true for every caller, not just
+ * `openDatabase()`. It is never set in production.
+ *
+ * XDG_DATA_HOME still wins: a test that manages its own data home is already
+ * controlled, and production has no test dir set at all.
  */
 export function getMagicContextStorageDir(): string {
-    return path.join(getDataDir(), "cortexkit", "magic-context");
+    const testDataDir = process.env.MAGIC_CONTEXT_TEST_DATA_DIR;
+    const base = testDataDir && !process.env.XDG_DATA_HOME ? testDataDir : getDataDir();
+    return path.join(base, "cortexkit", "magic-context");
 }
 
 /**

--- a/packages/plugin/src/shared/data-path.ts
+++ b/packages/plugin/src/shared/data-path.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { getHarness, type HarnessId } from "./harness";
@@ -176,18 +176,65 @@ export function getOpenCodeStorageDir(): string {
  * `PRAGMA integrity_check` against it. A test that deletes XDG_DATA_HOME to
  * exercise path fallbacks cannot restore isolation by setting
  * `process.env.HOME`: bun caches `os.homedir()` at startup, so `getDataDir()`
- * still resolves to the real home. Honoring MAGIC_CONTEXT_TEST_DATA_DIR here —
- * set by `packages/plugin/test-preload.ts` and mutated by no test — makes the
- * preload's "cannot be defeated" guarantee true for every caller, not just
- * `openDatabase()`. It is never set in production.
+ * still resolves to the real home. MAGIC_CONTEXT_TEST_DATA_DIR — set by
+ * `packages/plugin/test-preload.ts`, and restored by any test that touches it
+ * — is honored here, so the preload's "cannot be defeated" guarantee holds for
+ * every caller, not just `openDatabase()`. It is never set in production.
  *
- * XDG_DATA_HOME still wins: a test that manages its own data home is already
- * controlled, and production has no test dir set at all.
+ * CWD-INDEPENDENT BACKSTOP. The preload only runs when `bun test`'s CWD has a
+ * bunfig wiring `[test] preload`. A run from a dir WITHOUT that wiring (a
+ * package missing its bunfig, or a brand-new one) executes every *.test.ts with
+ * NO preload, and this resolver would hand back the REAL shared path — which is
+ * how the live DB reached v41. Bun sets NODE_ENV=test for EVERY `bun test`
+ * regardless of CWD, and production never sets it, so that window redirects to
+ * a memoized throwaway dir instead. It lives here rather than in
+ * `resolveDatabasePath()` so direct callers (the CLI doctors' own
+ * `PRAGMA integrity_check`, announcements, the models.dev cache) are covered
+ * too — they never go through the DB resolver.
+ *
+ * XDG_DATA_HOME still wins over both: a test that manages its own data home is
+ * already controlled, and production has no test dir set at all.
  */
 export function getMagicContextStorageDir(): string {
-    const testDataDir = process.env.MAGIC_CONTEXT_TEST_DATA_DIR;
-    const base = testDataDir && !process.env.XDG_DATA_HOME ? testDataDir : getDataDir();
-    return path.join(base, "cortexkit", "magic-context");
+    if (!process.env.XDG_DATA_HOME) {
+        const testDataDir = process.env.MAGIC_CONTEXT_TEST_DATA_DIR;
+        if (testDataDir) {
+            return path.join(testDataDir, "cortexkit", "magic-context");
+        }
+        if (process.env.NODE_ENV === "test") {
+            return getTestBackstopStorageDir();
+        }
+    }
+    return path.join(getDataDir(), "cortexkit", "magic-context");
+}
+
+let testBackstopStorageDir: string | null = null;
+let testBackstopWarned = false;
+
+/**
+ * Memoized per process so repeated calls in the same unisolated test resolve to
+ * the SAME path — `openDatabase()` caches by path, and a fresh temp dir per call
+ * would defeat that cache and hand back different DB handles.
+ */
+function getTestBackstopStorageDir(): string {
+    if (!testBackstopStorageDir) {
+        testBackstopStorageDir = path.join(
+            mkdtempSync(path.join(os.tmpdir(), "mc-test-db-backstop-")),
+            "cortexkit",
+            "magic-context",
+        );
+    }
+    if (!testBackstopWarned) {
+        testBackstopWarned = true;
+        // Deliberately console, not the logger: logger.ts imports this module.
+        console.warn(
+            "[magic-context] TEST BACKSTOP: NODE_ENV=test with no MAGIC_CONTEXT_TEST_DATA_DIR " +
+                `— redirecting storage to a throwaway temp dir (${testBackstopStorageDir}) so no ` +
+                "test can touch the user's real shared database. Wire `[test] preload` in this " +
+                "package's bunfig.toml.",
+        );
+    }
+    return testBackstopStorageDir;
 }
 
 /**


### PR DESCRIPTION
## Problem

`packages/plugin/test-preload.ts` documents `MAGIC_CONTEXT_TEST_DATA_DIR` as the guard that "cannot be defeated", but only `resolveDatabasePath()` consulted it. Every other caller of `getMagicContextStorageDir()` bypassed it — including the CLI doctors, which build `join(getMagicContextStorageDir(), "context.db")` themselves and run `PRAGMA integrity_check` against the result.

A test cannot restore isolation by setting `process.env.HOME`: bun caches `os.homedir()` at process startup, so `getDataDir()` still resolves to the real home.

```
HOME=/tmp/fakehome bun -e '... process.env.HOME="/tmp/mutated"; os.homedir()'
→ /tmp/fakehome   (mutation ignored)
```

Any test that deletes `XDG_DATA_HOME` to exercise path fallbacks therefore reaches the user's production database. Observed as two CLI doctor tests taking 8s and 16.5s against a 1.6 GB live DB — a read, not a migration, but the same escape route as the v26 and v41 incidents.

## Change

Move the guard into `getMagicContextStorageDir()` so every caller inherits it:

```ts
const testDataDir = process.env.MAGIC_CONTEXT_TEST_DATA_DIR;
const base = testDataDir && !process.env.XDG_DATA_HOME ? testDataDir : getDataDir();
return path.join(base, "cortexkit", "magic-context");
```

`XDG_DATA_HOME` still wins, so suites that manage their own data home are unaffected. `resolveDatabasePath()` drops the now-redundant branch and keeps the `NODE_ENV` backstop — that one needs a memoized throwaway dir, which a pure path helper has no business creating. The backstop's condition now defers to the test data dir, so precedence is exactly as before; otherwise a test that deleted only `XDG_DATA_HOME` would have been diverted from the preload dir into a fresh backstop dir.

3 files, +66/−24.

## Verification

To prove the hole is closed rather than merely unused, the pre-fix `doctor-omp.test.ts` (with `delete process.env.XDG_DATA_HOME` restored) was regenerated into a scratch file and run against the patched resolver: **101ms, 5 pass**, versus 34.65s and 2 failures before. The dangerous pattern is now inert.

Three new tests in `data-path.test.ts` pin the precedence: production layout (test dir lifted), guard honoured when `XDG_DATA_HOME` is unset, and `XDG_DATA_HOME` winning over the guard. The pre-existing layout test needed the test dir temporarily lifted — it had only been passing because the helper ignored the preload entirely.

Against a clean `master`:

- plugin suite 3621 pass / 0 fail across 346 files
- host e2e OpenCode 44 pass + cache-analysis oracle 10 pass, 0 fail
- host e2e Pi 47 pass / 12 skip (pre-existing `it.skip` placeholders) / 0 fail
- Docker e2e OpenCode 10/10, Docker e2e Pi 12/12 — these assert the shared DB lands at the production `cortexkit` path, confirming the guard stays inert when neither `NODE_ENV=test` nor `MAGIC_CONTEXT_TEST_DATA_DIR` is set
- typecheck, biome, `git diff --check` clean

The Rust e2e lane was not run: it needs a sibling `subconscious` checkout to build `ck-subc`, which CI also does not provision.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/magic-context/pr/296"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788956868&installation_model_id=22398&pr_number=296&repository=cortexkit%2Fmagic-context&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Fmagic-context%2Fpull%2F296&signature=1b0aed80f7c58de50fc229b3215789d2c0545f84c448261773340d2500cc6b54"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes test isolation by honoring `MAGIC_CONTEXT_TEST_DATA_DIR` and moving the `NODE_ENV=test` backstop into `getMagicContextStorageDir()` so tests, CLI doctors, and other direct callers never touch the real DB when `XDG_DATA_HOME` is unset or preload is missing. Keeps precedence and simplifies path resolution.

- **Bug Fixes**
  - Hoist the `NODE_ENV=test` backstop into `getMagicContextStorageDir()` alongside `MAGIC_CONTEXT_TEST_DATA_DIR`; covers CLI doctors, announcements, and models-dev cache.
  - Preserve precedence: `XDG_DATA_HOME` > `MAGIC_CONTEXT_TEST_DATA_DIR` > `NODE_ENV=test` backstop > default.
  - Remove isolation branches from `resolveDatabasePath()`; rely on the shared resolver.
  - Tests: add precedence/backstop coverage and snapshot/restore all guard env vars (incl. `NODE_ENV`) to prevent leaks; doctor test drops from ~34s to ~100ms with no production DB access.

<sup>Written for commit 86a7d56f3f024ae2af5f26f7362b5505d60a2c60. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/magic-context/pull/296?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR centralizes test-storage isolation in the shared storage resolver so direct callers and database-opening paths use consistent precedence.
- Preserves explicit database-path overrides.
- Resolves storage in the order `XDG_DATA_HOME`, `MAGIC_CONTEXT_TEST_DATA_DIR`, `NODE_ENV=test` backstop, then the platform default.
- Adds precedence, isolation, and environment-restoration coverage.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/plugin/src/shared/data-path.ts | Centralizes test-directory and test-runner backstop precedence for every shared-storage caller. |
| packages/plugin/src/features/magic-context/storage-db.ts | Removes duplicate test-isolation logic and delegates default database-path resolution to the shared helper. |
| packages/plugin/src/shared/data-path.test.ts | Adds coverage for production layout, test guard precedence, memoization, and environment restoration. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[getMagicContextStorageDir] --> B{XDG_DATA_HOME set?}
    B -- Yes --> C[XDG data directory]
    B -- No --> D{MAGIC_CONTEXT_TEST_DATA_DIR set?}
    D -- Yes --> E[Test data directory]
    D -- No --> F{NODE_ENV equals test?}
    F -- Yes --> G[Memoized temporary directory]
    F -- No --> H[Platform default data directory]
    C --> I[cortexkit/magic-context]
    E --> I
    G --> I
    H --> I
```
</details>

<sub>Reviews (3): Last reviewed commit: ["test(data-path): restore-or-delete every..."](https://github.com/cortexkit/magic-context/commit/86a7d56f3f024ae2af5f26f7362b5505d60a2c60) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51795794)</sub>

<!-- /greptile_comment -->