### PR TITLE
ci: pin the three remaining check jobs to --frozen-lockfile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
           node-version: "24"
 
       - name: Install dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: TypeScript typecheck
         run: bun run typecheck
@@ -101,7 +101,7 @@ jobs:
           bun-version: latest
 
       - name: Install dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: TypeScript typecheck
         run: bun run --cwd packages/pi-plugin typecheck
@@ -126,7 +126,7 @@ jobs:
           bun-version: latest
 
       - name: Install dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
 
       # Frontend-only checks (no Rust/Tauri needed). The key gate is the test
       # step, which runs config-parity.test.ts — it fails the build if the


### PR DESCRIPTION
Closes #295. One-line change ×3, off clean `master` @ `328c0fdc`.

`check-plugin` (48), `check-pi-plugin` (104), `check-dashboard` (129) → `bun install --frozen-lockfile`, matching the four later jobs.

## Verification

On a clean `upstream/master` worktree:

- `bun install --frozen-lockfile` succeeds — 1447 packages, exit 0. The lockfile is consistent with the manifests, so pinning does not break the install.
- The resulting `node_modules` resolves **biome 2.5.1** — the version `biome check .` actually executes — rather than the floated 2.5.7.
- Repo-wide `bun run lint` passes under the pinned install.

One detail worth recording, since it nearly misled me: `bunx @biomejs/biome --version` reports **2.5.7** even after a frozen install, because `bunx` resolves from the registry rather than `node_modules`. The lint scripts run `biome check .` through the package's local binary, which is 2.5.1. So a `bunx` probe is the wrong instrument here — `./node_modules/.bin/biome --version` is the one that reflects what CI runs.

## Tradeoff

As discussed on the issue: this gives up the incidental early-warning property of floating installs, in exchange for reproducible CI and toolchain upgrades landing as explicit lockfile commits. Flagging it in the commit message too so the reasoning is discoverable from `git log` and not only from the issue thread.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/magic-context/pr/299"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788963570&installation_model_id=22398&pr_number=299&repository=cortexkit%2Fmagic-context&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Fmagic-context%2Fpull%2F299&signature=9605d4b3573b60c439071d68655ad1010ecbd8beb5c75566938dd9e2566af63e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins the `check-plugin`, `check-pi-plugin`, and `check-dashboard` CI jobs to use `bun install --frozen-lockfile`. This prevents dependency drift (e.g., `@biomejs/biome` 2.5.7 vs 2.5.1) and makes CI installs reproducible, addressing #295.

<sup>Written for commit c0c63cb246cc6c79cf55e945f0438b74ae81d766. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/magic-context/pull/299?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR makes the remaining three CI check jobs install dependencies from the committed Bun lockfile, preventing unreviewed dependency drift.
- Adds `--frozen-lockfile` to dependency installation in `check-plugin`.
- Applies the same reproducible installation behavior to `check-pi-plugin` and `check-dashboard`.
- Aligns these checks with the repository's existing end-to-end CI jobs.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because all three affected jobs can install from the consistent committed lockfile.

The change only enables Bun's frozen-lockfile enforcement for three root workspace installs, with no intervening manifest mutation and with equivalent frozen installs already used by sibling CI jobs.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/ci.yml | Pins dependency installation in three check jobs to the committed Bun lockfile; the lockfile and workspace manifests are consistent and no changed-code failure was identified. |

</details>

<sub>Reviews (1): Last reviewed commit: ["ci: pin the three remaining check jobs t..."](https://github.com/cortexkit/magic-context/commit/c0c63cb246cc6c79cf55e945f0438b74ae81d766) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51826394)</sub>

<!-- /greptile_comment -->