### PR TITLE
fix(inject-compartments): scope the injection cache to its source database

### DIFF
--- a/packages/plugin/src/hooks/magic-context/degraded-reanchor.test.ts
+++ b/packages/plugin/src/hooks/magic-context/degraded-reanchor.test.ts
@@ -392,6 +392,38 @@ describe("Layer B — degraded-mode re-anchor (#264)", () => {
         expect(pass2Messages[1].info.id).toBe("msg_y");
     });
 
+    it("does not inherit another database's degraded count for the same session id", () => {
+        // The degraded count gates a byte-CHANGING re-anchor. If it leaks across
+        // stores sharing a session id, store B re-anchors on its FIRST degraded
+        // pass because it inherited store A's episode.
+        const makeVisible = (): MessageLike[] => [
+            userMessage("msg_c1_end", "compartment one end"),
+            userMessage("msg_x", "x"),
+        ];
+
+        // Store A: one degraded bust pass (count = 1, below the threshold).
+        seedTwoCompartments();
+        const storeAPass = prepareCompartmentInjection(db, SESSION_ID, makeVisible(), true);
+        expect(storeAPass?.compartmentEndMessageId).toBeNull();
+
+        // Store B: independent database, same session id, its FIRST degraded pass.
+        const storeA = db;
+        const storeB = makeContextDb();
+        try {
+            db = storeB;
+            seedTwoCompartments();
+            const messages = makeVisible();
+            const storeBPass = prepareCompartmentInjection(storeB, SESSION_ID, messages, true);
+            // Still pass 1 for THIS store: no re-anchor, nothing spliced.
+            expect(storeBPass?.compartmentEndMessageId).toBeNull();
+            expect(storeBPass?.skippedVisibleMessages).toBe(0);
+            expect(messages.length).toBe(2);
+        } finally {
+            db = storeA;
+            closeQuietly(storeB);
+        }
+    });
+
     it("does NOT re-anchor before the degraded-pass threshold", () => {
         seedTwoCompartments();
         const makeVisible = (): MessageLike[] => [

--- a/packages/plugin/src/hooks/magic-context/inject-compartments.test.ts
+++ b/packages/plugin/src/hooks/magic-context/inject-compartments.test.ts
@@ -322,6 +322,41 @@ describe("prepareCompartmentInjection — empty compartments fallback", () => {
     });
 });
 
+describe("prepareCompartmentInjection — cross-database cache isolation", () => {
+    it("does not replay a block rendered from a different database", () => {
+        // The injection cache is process-global and keyed by session id alone,
+        // while the value it holds is rendered FROM a database. Two independent
+        // stores that share a session id must not see each other's blocks.
+        const first = makeDb();
+        try {
+            insertMemory(first, {
+                projectPath: PROJECT_PATH,
+                category: "CONSTRAINTS",
+                content: "MEMORY-ONLY-IN-FIRST-DATABASE",
+            });
+            const populated = prepareCompartmentInjection(
+                first,
+                SESSION_ID,
+                [userMessage("m1", "hi")],
+                true,
+                PROJECT_PATH,
+            );
+            expect(populated?.block).toContain("MEMORY-ONLY-IN-FIRST-DATABASE");
+        } finally {
+            closeQuietly(first);
+        }
+
+        // Second store: same session id, no memories, and a DEFER pass — the
+        // path that replays the cached injection.
+        db = makeDb();
+        const messages: MessageLike[] = [userMessage("m1", "hi")];
+        const replayed = prepareCompartmentInjection(db, SESSION_ID, messages, false, PROJECT_PATH);
+
+        expect(replayed?.block ?? "").not.toContain("MEMORY-ONLY-IN-FIRST-DATABASE");
+        expect(replayed).toBeNull();
+    });
+});
+
 describe("prepareCompartmentInjection — workspace memory sharing", () => {
     it("renders only explicitly shared foreign memory categories", () => {
         db = makeDb();

--- a/packages/plugin/src/hooks/magic-context/inject-compartments.ts
+++ b/packages/plugin/src/hooks/magic-context/inject-compartments.ts
@@ -93,8 +93,8 @@ export interface PreparedCompartmentInjection {
  */
 const INJECTION_CACHE_MAX = 100;
 type InjectionCacheEntry =
-    | { kind: "empty"; compartmentEndMessageId: string; renderedBytes: number }
-    | { kind: "populated"; injection: PreparedCompartmentInjection };
+    | { db: Database; kind: "empty"; compartmentEndMessageId: string; renderedBytes: number }
+    | { db: Database; kind: "populated"; injection: PreparedCompartmentInjection };
 
 const injectionCache = new BoundedSessionMap<InjectionCacheEntry>(INJECTION_CACHE_MAX);
 
@@ -319,11 +319,19 @@ export function prepareCompartmentInjection(
     // On defer (cache-safe) passes, replay the cached injection result so that
     // historian publications between passes do not bust the prompt-cache prefix.
     const cached = injectionCache.get(sessionId);
-    if (!isCacheBusting && cached) {
-        if (cached.kind === "empty") {
+    if (cached && cached.db !== db) {
+        // Session ids are unique in production, but tests and explicit database
+        // paths can reuse one across independent stores. Never replay a block
+        // rendered from a different database into the current session.
+        injectionCache.delete(sessionId);
+    }
+    const usableCached = cached?.db === db ? cached : undefined;
+
+    if (!isCacheBusting && usableCached) {
+        if (usableCached.kind === "empty") {
             return null;
         }
-        const prepared = cached.injection;
+        const prepared = usableCached.injection;
         if (prepared.compartmentEndMessageId === null) {
             sessionLog(
                 sessionId,
@@ -418,6 +426,7 @@ export function prepareCompartmentInjection(
     // Nothing to inject if we have no compartments, no facts, and no memories
     if (compartments.length === 0 && facts.length === 0 && !memoryBlock) {
         injectionCache.set(sessionId, {
+            db,
             kind: "empty",
             compartmentEndMessageId: "",
             renderedBytes: 0,
@@ -462,7 +471,7 @@ export function prepareCompartmentInjection(
             memoryCount,
             rebuiltFromDb: true,
         };
-        injectionCache.set(sessionId, { kind: "populated", injection: result });
+        injectionCache.set(sessionId, { db, kind: "populated", injection: result });
         return result;
     }
 
@@ -527,7 +536,7 @@ export function prepareCompartmentInjection(
             memoryCount,
             rebuiltFromDb: true,
         };
-        injectionCache.set(sessionId, { kind: "populated", injection: result });
+        injectionCache.set(sessionId, { db, kind: "populated", injection: result });
         return result;
     }
 
@@ -614,7 +623,7 @@ export function prepareCompartmentInjection(
     if (needsFreshMaterialization) {
         result.needsFreshMaterialization = true;
     }
-    injectionCache.set(sessionId, { kind: "populated", injection: result });
+    injectionCache.set(sessionId, { db, kind: "populated", injection: result });
     return result;
 }
 

--- a/packages/plugin/src/hooks/magic-context/inject-compartments.ts
+++ b/packages/plugin/src/hooks/magic-context/inject-compartments.ts
@@ -323,7 +323,12 @@ export function prepareCompartmentInjection(
         // Session ids are unique in production, but tests and explicit database
         // paths can reuse one across independent stores. Never replay a block
         // rendered from a different database into the current session.
-        injectionCache.delete(sessionId);
+        //
+        // clearInjectionCache (not a bare delete) so the degraded-mode re-anchor
+        // bookkeeping is dropped with it: that count gates a byte-CHANGING
+        // re-anchor, so inheriting another store's episode could re-anchor early
+        // — the same cross-store leak, on the path where it costs more.
+        clearInjectionCache(sessionId);
     }
     const usableCached = cached?.db === db ? cached : undefined;
 


### PR DESCRIPTION
Closes #307. Off clean `master` @ `885e93dc`.

`injectionCache` is keyed on `sessionId` alone while holding database-derived content, so two independent stores sharing a session id replay each other's blocks. Cache entries now carry their `Database` handle; an entry whose `db` is not the current one is discarded instead of replayed, and every write records the db.

## Reproduction (clean master, before the fix)

Store A seeds a memory and renders; store B is empty, same session id, defer pass:

```
PROBE A: injected=true  hasMarker=true
PROBE B: injected=false LEAKED_FROM_A=true
```

With the fix: `LEAKED_FROM_A=false`, and B correctly returns `null`.

## What I deliberately did not touch

The defer-replay path is load-bearing for prompt-cache stability — it's what keeps `<session-history>` byte-identical across passes so a historian publish doesn't bust the prefix. The change adds an identity check **before** that path and leaves its behavior alone: same replay, same bytes, same conditions, for every entry whose db matches. Cache-stability tests (`replays date-bearing m[0]/m[1] bytes unchanged on consecutive defer passes`, the memories-only defer replay) pass unchanged.

I went looking for a cheaper fix first — clearing the cache in test teardown would paper over the symptom, but the invariant is a property of the cache, not of the tests, so it belongs at the cache.

## Verification

| | |
|---|---|
| plugin | 3758 pass / 0 fail |
| pi-plugin | 0 fail |
| typecheck | 0 across 3 packages |

RED-check: with the fix reverted, the new regression test fails with store A's marker present in store B's block — it genuinely guards the bug rather than passing vacuously.

`bun run lint` reports one pre-existing error in `latch-permanence-guard.test.ts`. That file is byte-identical to master here and fails identically on a clean master worktree under the lockfile-pinned Biome, so it's not from this change.

## Honest scope

I found this because it broke test isolation downstream — two suites using `ses-1` with separate temp databases, failing only when co-run. Session ids are unique per store in a normal run, so I'm not claiming a live-session failure and haven't constructed one. The claim is narrower: a cache keyed by session id shouldn't serve content rendered from a different database, and the check is cheap enough that the invariant seems worth holding regardless of whether a production path reaches it today.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/magic-context/pr/308"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789129033&installation_model_id=22398&pr_number=308&repository=cortexkit%2Fmagic-context&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Fmagic-context%2Fpull%2F308&signature=7eb26a787d7e69e1987aac234a0a28632cbe04e29a67ca9a241de651892f0a44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes the process-global injection cache to its source database and clears degraded re-anchor state on db mismatch. This prevents cross-database replays and early re-anchors when session IDs collide.

- **Bug Fixes**
  - Add `db` to `injectionCache` entries and call `clearInjectionCache(sessionId)` on a `db` mismatch to drop the entry and any degraded state.
  - Record `db` on all cache writes; same-database defer replay is unchanged.
  - Add regression tests to block replay across independent databases and to ensure no degraded-count inheritance for the same session ID.

<sup>Written for commit c6375bae0633ff2589b9c827b998a259f0aa2d15. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/magic-context/pull/308?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR scopes process-global compartment-injection cache entries to their source database while preserving replay behavior for matching database handles.
- Stores the originating database handle on every cache entry.
- Clears injection and degraded-reanchor state when a session-id collision crosses database boundaries.
- Adds regression coverage for injection replay and degraded-count isolation across databases.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/plugin/src/hooks/magic-context/inject-compartments.ts | Associates cached injections with their source database and rejects cross-database entries before replay while retaining same-database behavior. |
| packages/plugin/src/hooks/magic-context/inject-compartments.test.ts | Adds regression coverage proving that an empty database cannot replay memory rendered from another database sharing its session id. |
| packages/plugin/src/hooks/magic-context/degraded-reanchor.test.ts | Verifies that degraded-pass bookkeeping is reset rather than inherited when the same session id is reused with another database. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Prepare compartment injection] --> B{Cached session entry?}
    B -- No --> E[Build from current database]
    B -- Yes --> C{Cached database matches current database?}
    C -- No --> D[Clear injection and degraded-reanchor state]
    D --> E
    C -- Yes --> F{Cache-busting pass?}
    F -- No --> G[Replay cached result]
    F -- Yes --> E
    E --> H[Cache result with current database handle]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(inject-compartments): drop degraded ..."](https://github.com/cortexkit/magic-context/commit/c6375bae0633ff2589b9c827b998a259f0aa2d15) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52558579)</sub>

<!-- /greptile_comment -->