### PR TITLE
fix(conflict-detector): an absent compaction block is not a resolved default

### DIFF
--- a/packages/plugin/src/shared/conflict-detector.test.ts
+++ b/packages/plugin/src/shared/conflict-detector.test.ts
@@ -609,18 +609,68 @@ describe("detectConflicts", () => {
             expect(result).toEqual({ auto: false, prune: true });
         });
 
-        it("mirrors the SDK default semantics when compaction is absent (auto=true, prune=false)", async () => {
-            // The OpenCode schema annotates compaction.auto with default true and
-            // compaction.prune with default false (packages/core/src/v1/config/
-            // config.ts in the opencode repo), so an absent compaction block
-            // resolves to { auto: true, prune: false }.
+        it("returns null when the response carries NO compaction block (absent is not a value)", async () => {
+            // REGRESSION (live 2026-08-14): this previously returned
+            // { auto: true, prune: false }, treating "the host did not report this
+            // field" as "the host resolved the default". Those are different
+            // claims. The SDK's generated Config type has no compaction key at
+            // all, so on such an SDK the block is ALWAYS absent -- the old default
+            // made Magic Context disable itself on every boot regardless of the
+            // user's actual config, which is the very bug #309 set out to fix.
+            // Absent => we learned nothing => fall back to the file-based check.
             const client = {
                 config: {
                     get: async () => ({ data: {} }),
                 },
             };
             const result = await resolveCompactionForBoot(client);
-            expect(result).toEqual({ auto: true, prune: false });
+            expect(result).toBeNull();
+        });
+
+        it("reproduces the live failure: an SDK whose Config omits compaction must not disable the plugin", async () => {
+            // Exactly what opencode 1.18.15 + @opencode-ai/sdk 1.15.13 returns:
+            // a fully-populated resolved config with every key EXCEPT compaction,
+            // because the SDK schema does not declare one. The user's real
+            // opencode.jsonc has compaction.auto=false.
+            const client = {
+                config: {
+                    get: async () => ({
+                        data: {
+                            $schema: "https://opencode.ai/config.json",
+                            model: "anthropic/claude-opus-5",
+                            instructions: ["AGENTS.md"],
+                            plugin: ["file:///home/user/magic-context/packages/plugin"],
+                        },
+                    }),
+                },
+            };
+            const result = await resolveCompactionForBoot(client);
+            // null routes the caller to the file-based check, which reads the
+            // user's actual auto=false. Returning { auto: true } here is what
+            // disabled the plugin on every boot.
+            expect(result).toBeNull();
+        });
+
+        it("a PRESENT block is authoritative and keeps the host's per-field defaults", async () => {
+            // Partial block: the host really is reporting a resolved object, so
+            // per-field defaults (auto true, prune false) still apply within it.
+            const client = {
+                config: {
+                    get: async () => ({ data: { compaction: { prune: true } } }),
+                },
+            };
+            const result = await resolveCompactionForBoot(client);
+            expect(result).toEqual({ auto: true, prune: true });
+        });
+
+        it("an explicit auto=false in a present block is honored", async () => {
+            const client = {
+                config: {
+                    get: async () => ({ data: { compaction: { auto: false } } }),
+                },
+            };
+            const result = await resolveCompactionForBoot(client);
+            expect(result).toEqual({ auto: false, prune: false });
         });
 
         it("returns null when the client throws (file-based fallback used)", async () => {

--- a/packages/plugin/src/shared/conflict-detector.ts
+++ b/packages/plugin/src/shared/conflict-detector.ts
@@ -232,14 +232,25 @@ interface ResolvedCompactionBlock {
  * read would be wrongly flagged. We never re-derive what the host will tell
  * us.
  *
- * The OpenCode schema annotates `compaction.auto` with default `true` and
- * `compaction.prune` with default `false` (see
- * packages/core/src/v1/config/config.ts in the opencode repo), so an absent
- * compaction block resolves to `{ auto: true, prune: false }` — mirroring the
- * host's own default semantics rather than inventing our own.
+ * ABSENT IS NOT A VALUE. A response that carries no `compaction` block tells us
+ * NOTHING about the user's setting — it does not tell us the host resolved the
+ * default. Defaulting to `auto: true` there reintroduces exactly the bug #309
+ * set out to fix, one layer up: a plugin-disabling verdict derived from a field
+ * nobody reported. It is not hypothetical. The SDK's generated `Config` type has
+ * no `compaction` key at all (the only `compaction` in the SDK surface is the
+ * message-part variant `type: "compaction"`), so on an SDK whose schema omits it
+ * the block is ALWAYS absent, `?? true` always wins, and Magic Context disables
+ * itself on every boot no matter what the user configured.
  *
- * Returns `null` when the fetch fails or times out (bounded to `timeoutMs` so
- * boot never hangs), so the caller falls back to the file-based check.
+ * So: only a present block is authoritative. Within a present block the host's
+ * documented per-field defaults apply (`auto` true, `prune` false — see
+ * packages/core/src/v1/config/config.ts in the opencode repo), because there the
+ * host really is reporting a resolved object. An absent block returns `null`,
+ * which routes the caller to the file-based check — the same path used when the
+ * fetch fails, and the one that reads the user's actual config.
+ *
+ * Returns `null` when the fetch fails, times out (bounded to `timeoutMs` so boot
+ * never hangs), or reports no compaction block at all.
  */
 export async function resolveCompactionForBoot(
     client: OpencodeConfigClientLike,
@@ -254,11 +265,15 @@ export async function resolveCompactionForBoot(
         ]);
         // The SDK's generated `Config` type has no `compaction` key, so read it
         // defensively from the runtime response.
-        const compaction = (result?.data as ResolvedCompactionBlock | undefined)?.compaction;
-        // Mirror the host's defaults: auto defaults true, prune defaults false.
+        const data = result?.data as ResolvedCompactionBlock | undefined;
+        const compaction = data?.compaction;
+        // Absent block => we learned nothing. Fall back to the file-based check
+        // rather than inventing a plugin-disabling default from silence.
+        if (!compaction || typeof compaction !== "object") return null;
+        // Present block => authoritative, with the host's per-field defaults.
         return {
-            auto: compaction?.auto ?? true,
-            prune: compaction?.prune ?? false,
+            auto: compaction.auto ?? true,
+            prune: compaction.prune ?? false,
         };
     } catch {
         return null;


### PR DESCRIPTION
## What happens

On `master`, Magic Context disables itself on every boot:

```
[magic-context] disabled due to conflicts: OpenCode auto-compaction is enabled (compaction.auto=true) (resolved config)
```

The user's config says otherwise. `~/.config/opencode/opencode.jsonc` has `compaction.auto: false` at the top level, and `opencode debug config` — the authority the code comment names — agrees:

```json
{ "auto": false, "prune": false, "reserved": 50000 }
```

Observed on opencode `1.18.15` with `@opencode-ai/sdk` `1.15.13`, immediately after picking up `801cfd02`.

## Cause

`resolveCompactionForBoot` fills a missing `compaction` block with the schema default:

```ts
const compaction = (result?.data as ResolvedCompactionBlock | undefined)?.compaction;
return {
    auto: compaction?.auto ?? true,
    prune: compaction?.prune ?? false,
};
```

"The host did not report this field" and "the host resolved the default" are different claims. Only the second justifies a plugin-disabling verdict.

The distinction is load-bearing rather than academic, because **the SDK's generated `Config` type declares no `compaction` key at all.** The only `compaction` anywhere in its surface is the message-part variant:

```ts
// @opencode-ai/sdk/dist/gen/types.gen.d.ts:342
type: "compaction";
```

So on such an SDK the block is *always* absent, `?? true` *always* wins, and the plugin disables itself regardless of what the user configured. The existing code comment anticipates the type gap — "The SDK's generated `Config` type has no `compaction` key, so read it defensively from the runtime response" — but the defensive read then treats absence as a value.

That `resolveCompactionForBoot` returned rather than threw is confirmed by what is *missing* from the log: the fetch-failed path emits

```
[magic-context] resolved-config fetch failed; using file-based compaction detection …
```

which never appears. So this is the absent-block default, not a failed or timed-out request.

## Why this is #309 again

`801cfd02` moved the compaction read from files to the SDK precisely because the file-based path defaulted to `auto=true` and wrongly disabled the plugin for users whose `auto=false` lived in a layer we could not see.

The replacement kept the phantom default and only changed where it came from. Before: "no file resolved, assume auto=true." After: "no field reported, assume auto=true." Same verdict, same cause, one layer up.

## Fix

A **present** block stays authoritative and keeps the host's documented per-field defaults (`auto` true, `prune` false) — there the host really is reporting a resolved object, so a partial block is a genuine partial resolution.

An **absent** block returns `null`, routing the caller to the file-based check. That is not a new code path: it is the same fallback a failed fetch already takes, and it is the path that reads the user's actual configuration.

```ts
if (!compaction || typeof compaction !== "object") return null;
return { auto: compaction.auto ?? true, prune: compaction.prune ?? false };
```

## Tests

The existing case `"mirrors the SDK default semantics when compaction is absent (auto=true, prune=false)"` asserted the broken behavior, so it is **replaced** rather than added to — it encoded the defect as intent.

Four cases now cover the boundary:

| case | expected |
|---|---|
| no `compaction` key | `null` (fall back) |
| full resolved config with every key *except* `compaction` — the live shape | `null` (fall back) |
| present partial block `{ prune: true }` | `{ auto: true, prune: true }` |
| present `{ auto: false }` | `{ auto: false, prune: false }` |

**Mutation check.** Reverting the guard and restoring `compaction?.auto ?? true` reddens exactly the two new absent-block tests, `46 pass / 2 fail`. The two present-block tests pass under both implementations, which is what makes the red meaningful rather than vacuous — they confirm the fix is narrow and did not simply invert the function.

```
with fix:     48 pass, 0 fail
without fix:  46 pass, 2 fail   ← both new regression tests
full suite:   3821 pass, 0 fail (357 files, this branch on master)
```

Typecheck and lint clean.

## Note on scope

This does not attempt to make the SDK expose `compaction`; that is an upstream-opencode question and may well be intentional. The point here is narrower: whatever the SDK chooses to report, a field it does not report must not be read as a plugin-disabling setting. If the SDK later adds the key, the present-block path picks it up with no further change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/magic-context/pr/317"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789312356&installation_model_id=22398&pr_number=317&repository=cortexkit%2Fmagic-context&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Fmagic-context%2Fpull%2F317&signature=ecde830afe9373b6849b2c3a628af606628c88af4f6de87f6f5be2595cb59b73"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops disabling Magic Context when the host omits the compaction block. Previously, an absent compaction block was treated as `{ auto: true }`; now absence means “unknown” and falls back to the file-based check, honoring the user’s config.

- Change: `resolveCompactionForBoot` returns null when no `compaction` object is present; when present, it applies per-field defaults within that object (`auto` true, `prune` false).
- Impact: Prevents false positives with SDKs that don’t expose `compaction` (e.g., `@opencode-ai/sdk` 1.15.13), where the plugin was disabled on every boot despite `auto=false`.
- Tests: Replaces the prior “absent means defaults” assertion and adds cases for absent block, present partials, and explicit `auto=false`.
- Rollout: No migration required. Fallback and timeout behavior are unchanged and still return null.

<sup>Written for commit 02ce7298baa7bcb82f7ea3d96409362df0789aba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/magic-context/pull/317?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR distinguishes an omitted SDK `compaction` block from a resolved default and routes omission to existing file-based conflict detection.
- Returns `null` when the SDK response has no compaction object.
- Preserves per-field defaults for present partial compaction objects.
- Adds regression coverage for absent and partial response shapes.
- The selected fallback remains unable to resolve some supported OpenCode configuration layers.
</details>

<h3>Confidence Score: 4/5</h3>

The PR should not merge until absent SDK fields are handled without falsely disabling the plugin for effective settings supplied through configuration layers the fallback cannot inspect.

Returning null for an omitted SDK field routes boot conflict detection through a known-incomplete file reader, which can still default auto-compaction to enabled and disable Magic Context despite an effective auto=false setting.

**Files Needing Attention:** packages/plugin/src/shared/conflict-detector.ts

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/plugin/src/shared/conflict-detector.ts | Changes absent-block handling to invoke a fallback that still cannot represent all effective OpenCode configuration layers. |
| packages/plugin/src/shared/conflict-detector.test.ts | Covers helper return values for absent and partial blocks, but does not exercise boot behavior when the effective setting comes from a fallback-invisible layer. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[SDK config response] --> B{compaction block present?}
  B -->|Yes| C[Use resolved block and per-field defaults]
  B -->|No| D[Return null]
  D --> E[Boot omits resolvedCompaction]
  E --> F[File-based detection]
  F --> G{Setting found in inspected files?}
  G -->|Yes| H[Use file value]
  G -->|No| I[Default auto=true]
  I --> J[Conflict disables plugin]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(conflict-detector): an absent compac..."](https://github.com/cortexkit/magic-context/commit/02ce7298baa7bcb82f7ea3d96409362df0789aba) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53365144)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Magic Context plugin runtime](https://app.greptile.com/cortexkit/-/custom-context/knowledge-base/cortexkit/magic-context/-/docs/plugin-runtime.md)

<!-- /greptile_comment -->