### PR TITLE
fix(dashboard): classify models.window_overlay_path in the coverage manifest

### DIFF
--- a/packages/dashboard/src/components/ConfigEditor/config-field-coverage.ts
+++ b/packages/dashboard/src/components/ConfigEditor/config-field-coverage.ts
@@ -99,6 +99,11 @@ export const OMITTED_BY_DESIGN: Readonly<Record<string, string>> = {
     "user-only inoperability policy; raw JSONC because project configs cannot change it",
   "smart_notes.retina_handoff":
     "external-events plane flip; stays raw JSONC until the retina consumer ships and the flag has a user-facing meaning",
+  // Listed as the exact leaf rather than omitting the whole `models` subtree, so
+  // a future sibling field still trips this gate instead of being absorbed by a
+  // prefix match.
+  "models.window_overlay_path":
+    "user-only Fusiform overlay path; raw JSONC because it is a filesystem location with a computed default (<dataDir>/fusiform/window-overlay.json), not a value worth a form widget",
 };
 
 /**


### PR DESCRIPTION
## What happens

`Check (dashboard)` is red on `master`, so it is red on every PR against it — including PRs that touch nothing in the dashboard.

```
(fail) ConfigEditor ⇄ schema parity > #given the generated schema
       #then every leaf field is classified (rendered or omitted-by-design)

- []
+ [ "models.window_overlay_path" ]

43 pass, 1 fail
```

Reproduced on upstream tip `67bac308` with no local changes:

```
$ git checkout 67bac308
$ cd packages/dashboard && bun test src/components/ConfigEditor/config-parity.test.ts
5 pass, 1 fail   ← uncovered = ["models.window_overlay_path"]
```

## Cause

`models.window_overlay_path` was added to the plugin config schema by `9f4d90ae` ("mason: derive usable context window geometry"):

```ts
// packages/plugin/src/config/schema/magic-context.ts:731
models: z.object({ window_overlay_path: z.string().trim().min(1).optional() }).optional()
```

The dashboard's parity gate requires every schema leaf to be either rendered by the form or listed in `OMITTED_BY_DESIGN` with a reason. This one is neither.

Worth saying plainly: this is the gate doing its job. It exists to catch a schema leaf landing without a dashboard decision, and it caught one. The fix is to record the decision, not to weaken the check.

## Fix

Recorded as `OMITTED_BY_DESIGN`. It is a user-only filesystem path with a computed default (`<dataDir>/fusiform/window-overlay.json`) — the same class as the existing `subc` and `fail_closed_blocking` omissions. A path override is a raw-JSONC choice, not a value worth a form widget.

One deliberate detail: the entry names the **exact leaf**, not the `models` subtree. Omitting `models` wholesale would classify every future field under it by prefix match, so the next sibling would land silently instead of tripping this gate. Keeping it leaf-scoped preserves that.

If the maintainers would rather surface it as a widget, say so and I will swap the entry for a `RENDERED_PREFIXES` addition plus the input — the manifest entry is the minimal correct move, not a claim that it should never be rendered.

## Verification

| | result |
|---|---|
| parity test on `67bac308`, no changes | 5 pass / **1 fail** |
| parity test with this commit | **6 pass / 0 fail** |
| full dashboard suite | **44 pass / 0 fail** |
| lint | clean |

One line of manifest plus its reason comment; no test, source, or schema changes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/magic-context/pr/318"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789323267&installation_model_id=22398&pr_number=318&repository=cortexkit%2Fmagic-context&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Fmagic-context%2Fpull%2F318&signature=b34f6a69b47bbc70370df5e08c370dff7e1dc04cbf35833c62967f698e3b747b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Classifies `models.window_overlay_path` in the dashboard config coverage manifest to restore the parity gate. Previously the leaf was neither rendered nor omitted; now it is marked OMITTED_BY_DESIGN with rationale, so the dashboard check passes with no UI change.

- The field is a user-only filesystem path with a computed default (<dataDir>/fusiform/window-overlay.json); it remains a raw JSONC override, not a form widget.
- The omission targets the exact leaf, not the `models` subtree, so future siblings still trigger the gate.
- No runtime or schema changes; tests now pass; no migration required.

<sup>Written for commit 75a512136abc060f974cb1b5dca796ee83e388a6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/magic-context/pull/318?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds an exact-leaf coverage-manifest classification for `models.window_overlay_path`, restoring the dashboard schema-parity gate without suppressing coverage checks for future `models` fields.
- Classifies the user-only overlay path as omitted by design.
- Documents why the exact leaf is used instead of the entire `models` subtree.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge; the narrowly scoped manifest entry restores schema-parity coverage without changing runtime configuration behavior.

The exact-leaf omission matches the coverage matcher, the field’s user-only scope and computed default, and does not classify future sibling fields.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/dashboard/src/components/ConfigEditor/config-field-coverage.ts | Correctly classifies the existing schema leaf as intentionally omitted while preserving parity failures for future sibling fields. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(dashboard): classify models.window\_o..."](https://github.com/cortexkit/magic-context/commit/75a512136abc060f974cb1b5dca796ee83e388a6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53420270)</sub>

**Context used:**

- Knowledge Base — [Desktop dashboard: Solid UI over Tauri, serve transport, and shared stores](https://app.greptile.com/cortexkit/-/custom-context/knowledge-base/cortexkit/magic-context/-/docs/dashboard.md)

<!-- /greptile_comment -->