### PR TITLE
test: remove shared-DB and timer flakiness

### DIFF
--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -39,7 +39,7 @@
     "build:tui": "bun scripts/build-tui.ts",
     "check:tui-compiled": "bun run build:tui && git diff --exit-code -- src/tui-compiled && test -z \"$(git status --porcelain -- src/tui-compiled)\"",
     "typecheck": "tsc -p ../retina-local-fs/tsconfig.build.json && tsc --noEmit && tsc -p tsconfig.scripts.json",
-    "test": "bun test --isolate",
+    "test": "bun test --timeout 30000",
     "lint": "biome check .",
     "lint:fix": "biome check --write .",
     "format": "biome format --write .",

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -39,7 +39,7 @@
     "build:tui": "bun scripts/build-tui.ts",
     "check:tui-compiled": "bun run build:tui && git diff --exit-code -- src/tui-compiled && test -z \"$(git status --porcelain -- src/tui-compiled)\"",
     "typecheck": "tsc -p ../retina-local-fs/tsconfig.build.json && tsc --noEmit && tsc -p tsconfig.scripts.json",
-    "test": "bun test",
+    "test": "bun test --isolate",
     "lint": "biome check .",
     "lint:fix": "biome check --write .",
     "format": "biome format --write .",

--- a/packages/plugin/src/features/magic-context/message-index-async.test.ts
+++ b/packages/plugin/src/features/magic-context/message-index-async.test.ts
@@ -1,6 +1,6 @@
 /// <reference types="bun-types" />
 
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, jest } from "bun:test";
 
 import type { RawMessage } from "../../hooks/magic-context/read-session-raw";
 import { BOOT_QUIET_MS, setBootQuietPeriodForTests } from "../../plugin/boot-quiet";
@@ -114,6 +114,7 @@ describe("message-index-async", () => {
 
     afterEach(() => {
         setBootQuietPeriodForTests(null);
+        jest.useRealTimers();
         closeQuietly(db);
         __resetMessageIndexAsyncForTests();
     });
@@ -359,6 +360,8 @@ describe("message-index-async", () => {
     });
 
     it("rebuilds when removal overtakes a boot-quiet reconciliation", async () => {
+        jest.useFakeTimers();
+        jest.setSystemTime(0);
         const sessionId = "ses-boot-clear";
         const surviving = [message("m-survivor", 1, "surviving searchable bytes")];
         let reads = 0;
@@ -366,13 +369,15 @@ describe("message-index-async", () => {
             reads++;
             return surviving;
         };
-        setBootQuietPeriodForTests(Date.now() - BOOT_QUIET_MS + 20);
+        setBootQuietPeriodForTests(0);
 
-        scheduleReconciliation(db, sessionId, readSurviving);
-        scheduleClearAndReindex(db, sessionId, readSurviving);
+        const reconciliationFinished = scheduleReconciliation(db, sessionId, readSurviving);
+        const rebuildFinished = scheduleClearAndReindex(db, sessionId, readSurviving);
         expect(isSessionReconciled(sessionId)).toBe(false);
 
-        await wait(80);
+        jest.advanceTimersByTime(BOOT_QUIET_MS);
+        jest.runAllTimers();
+        await Promise.all([reconciliationFinished, rebuildFinished]);
 
         expect(reads).toBe(2);
         expect(countMessageRows(db, sessionId, "m-survivor")).toBe(1);

--- a/packages/plugin/src/features/magic-context/message-index-async.ts
+++ b/packages/plugin/src/features/magic-context/message-index-async.ts
@@ -73,7 +73,7 @@ const INCREMENTAL_DEBOUNCE_MS = 100;
 const RECONCILIATION_BATCH_SIZE = 100;
 
 const reconciledSessions = new Set<string>();
-const reconciliationScheduledSessions = new Set<string>();
+const reconciliationScheduledSessions = new Map<string, Promise<void>>();
 const sessionLocks = new Map<string, Promise<void>>();
 const incrementalTimers = new Map<string, ReturnType<typeof setTimeout>>();
 const pendingIncrementalKeys = new Set<string>();
@@ -199,23 +199,29 @@ export function scheduleReconciliation(
     db: Database,
     sessionId: string,
     readMessages: ReadMessages,
-): void {
-    if (reconciledSessions.has(sessionId) || reconciliationScheduledSessions.has(sessionId)) {
-        return;
-    }
-    reconciliationScheduledSessions.add(sessionId);
+): Promise<void> {
+    if (reconciledSessions.has(sessionId)) return Promise.resolve();
+    const scheduled = reconciliationScheduledSessions.get(sessionId);
+    if (scheduled) return scheduled;
 
-    scheduleAfterBootQuiet(() => {
-        defer(() => {
-            void reconcileSessionIndex(db, sessionId, readMessages)
-                .catch((error) => {
-                    logIndexingError(sessionId, "reconciliation", error);
-                })
-                .finally(() => {
-                    reconciliationScheduledSessions.delete(sessionId);
-                });
+    const completion = new Promise<void>((resolve) => {
+        scheduleAfterBootQuiet(() => {
+            defer(() => {
+                void reconcileSessionIndex(db, sessionId, readMessages)
+                    .catch((error) => {
+                        logIndexingError(sessionId, "reconciliation", error);
+                    })
+                    .finally(() => {
+                        if (reconciliationScheduledSessions.get(sessionId) === completion) {
+                            reconciliationScheduledSessions.delete(sessionId);
+                        }
+                        resolve();
+                    });
+            });
         });
     });
+    reconciliationScheduledSessions.set(sessionId, completion);
+    return completion;
 }
 
 export function scheduleIncrementalIndex(
@@ -275,26 +281,29 @@ export function scheduleClearAndReindex(
     db: Database,
     sessionId: string,
     readMessages: ReadMessages,
-): void {
+): Promise<void> {
     reconciledSessions.delete(sessionId);
     reconciliationScheduledSessions.delete(sessionId);
     clearCompletedIncrementalKeys(sessionId);
 
-    scheduleAfterBootQuiet(() => {
-        defer(() => {
-            void runWithSessionLock(sessionId, () => {
-                // An older boot-quiet reconciliation can finish after this clear was
-                // scheduled, so invalidate process state under the same session lock
-                // that clears the durable index.
-                reconciledSessions.delete(sessionId);
-                clearCompletedIncrementalKeys(sessionId);
-                clearIndexedMessages(db, sessionId);
-            })
-                .then(() => reconcileSessionIndex(db, sessionId, readMessages))
-                .catch((error) => {
+    return new Promise<void>((resolve) => {
+        scheduleAfterBootQuiet(() => {
+            defer(() => {
+                void runWithSessionLock(sessionId, () => {
+                    // An older boot-quiet reconciliation can finish after this clear was
+                    // scheduled, so invalidate process state under the same session lock
+                    // that clears the durable index.
                     reconciledSessions.delete(sessionId);
-                    logIndexingError(sessionId, "clear and reindex", error);
-                });
+                    clearCompletedIncrementalKeys(sessionId);
+                    clearIndexedMessages(db, sessionId);
+                })
+                    .then(() => reconcileSessionIndex(db, sessionId, readMessages))
+                    .catch((error) => {
+                        reconciledSessions.delete(sessionId);
+                        logIndexingError(sessionId, "clear and reindex", error);
+                    })
+                    .finally(resolve);
+            });
         });
     });
 }

--- a/packages/plugin/src/features/magic-context/storage-embedding-measurements.test.ts
+++ b/packages/plugin/src/features/magic-context/storage-embedding-measurements.test.ts
@@ -62,30 +62,32 @@ describe("embedding measurement corpus", () => {
         const db = openDatabase();
         const overflow = 5;
         const total = MEASUREMENT_CORPUS_SESSION_ROW_CAP + overflow;
-        for (let i = 0; i < total; i++) {
-            recordEmbeddingMeasurement(db, {
-                sessionId: "ses-cap",
-                projectPath: "/repo",
-                // Unique query text per row: dedup is on (query hash, cohort), so
-                // distinct queries simulate the cohort-transition growth.
-                queryText: `query ${i}`,
-                cohortKey: "fp-a:0|fp-b:0",
-                primaryResultIds: [],
-                shadowResultIds: [],
-                primaryLatencyMs: 1,
-                shadowLatencyMs: 1,
-                primaryFailed: false,
-                shadowFailed: false,
-                primaryModelId: "local-id",
-                shadowModelId: "synapse-id",
-                primaryFingerprint: "",
-                shadowFingerprint: "fp-b",
-                primaryEpoch: 0,
-                shadowEpoch: 0,
-                corpusHash: `corpus-${i}`,
-                coverage: {},
-            });
-        }
+        db.transaction(() => {
+            for (let i = 0; i < total; i++) {
+                recordEmbeddingMeasurement(db, {
+                    sessionId: "ses-cap",
+                    projectPath: "/repo",
+                    // Unique query text per row: dedup is on (query hash, cohort), so
+                    // distinct queries simulate the cohort-transition growth.
+                    queryText: `query ${i}`,
+                    cohortKey: "fp-a:0|fp-b:0",
+                    primaryResultIds: [],
+                    shadowResultIds: [],
+                    primaryLatencyMs: 1,
+                    shadowLatencyMs: 1,
+                    primaryFailed: false,
+                    shadowFailed: false,
+                    primaryModelId: "local-id",
+                    shadowModelId: "synapse-id",
+                    primaryFingerprint: "",
+                    shadowFingerprint: "fp-b",
+                    primaryEpoch: 0,
+                    shadowEpoch: 0,
+                    corpusHash: `corpus-${i}`,
+                    coverage: {},
+                });
+            }
+        })();
 
         const rows = listEmbeddingMeasurements(db, "ses-cap");
         expect(rows).toHaveLength(MEASUREMENT_CORPUS_SESSION_ROW_CAP);

--- a/packages/plugin/src/tui/tui-compiled-runtime-imports.test.ts
+++ b/packages/plugin/src/tui/tui-compiled-runtime-imports.test.ts
@@ -49,6 +49,9 @@ describe("compiled TUI runtime imports", () => {
      *  Built from the shared list so the test cannot cover fewer modules than the
      *  build rewrites. */
     async function loadExportSets(): Promise<Record<string, Set<string>>> {
+        // @opentui/core/testing subclasses a core export during module initialization;
+        // warm core before the parallel imports so Bun cannot expose its TDZ.
+        await import("@opentui/core");
         const entries = await Promise.all(
             TUI_RUNTIME_SPECIFIERS.map(
                 async (specifier) =>


### PR DESCRIPTION
## Summary
- set plugin test timeout to 30s so SQLite's 5s busy-timeout reports the actual lock stack instead of Bun killing the test first
- batch the 2,005 embedding-measurement setup inserts in one SQLite transaction
- return real completion promises from message-index schedulers and await them with a fake boot-quiet clock
- warm `@opentui/core` before parallel runtime-specifier imports to remove the `TreeSitterClient` TDZ race exposed by CI

Addresses #312 (improves lock-failure observability; per-file DB isolation remains open)
Fixes #330
Fixes #333

## Verification
- targeted storage/scheduler scope: 16 pass
- two concurrent targeted runners: both exit 0
- 20 repeated scheduler runs: pass
- 20 repeated TUI runtime-import runs: pass
- `bun run lint`
- `bun run typecheck`
- plugin build

Assertions are unchanged; no SQLite timeout was hidden or extended.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR reduces SQLite and scheduler test flakiness without changing production database timeout behavior.
- Extends the plugin test timeout to 30 seconds so SQLite lock failures surface before the test runner terminates them.
- Batches embedding-measurement fixture inserts in one transaction.
- Exposes scheduler completion promises and uses a fake boot-quiet clock in the overlap test.
- Serializes the TUI core/testing module initialization path.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/plugin/package.json | Raises the package test timeout so SQLite's configured busy timeout can produce a useful failure first. |
| packages/plugin/src/features/magic-context/message-index-async.ts | Returns deduplicated completion promises from reconciliation and clear/reindex scheduling while preserving per-session serialization. |
| packages/plugin/src/features/magic-context/message-index-async.test.ts | Replaces wall-clock waiting with fake timers and awaits both scheduler completion promises. |
| packages/plugin/src/features/magic-context/storage-embedding-measurements.test.ts | Batches the large measurement-corpus fixture setup in one SQLite transaction. |
| packages/plugin/src/tui/tui-compiled-runtime-imports.test.ts | Initializes the TUI core module before parallel runtime imports to avoid a module-initialization TDZ. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Test
    participant BootQuiet as Boot-quiet scheduler
    participant Lock as Session lock
    participant Index as Message index
    Test->>BootQuiet: schedule reconciliation
    Test->>BootQuiet: schedule clear and reindex
    Test->>BootQuiet: advance fake clock
    BootQuiet->>Lock: queue reconciliation
    BootQuiet->>Lock: queue clear and reindex
    Lock->>Index: reconcile existing messages
    Lock->>Index: clear indexed session
    Lock->>Index: rebuild from surviving messages
    Index-->>Test: resolve completion promises
```
</details>

<sub>Reviews (3): Last reviewed commit: ["test(tui): stabilize runtime import orde..."](https://github.com/cortexkit/magic-context/commit/d166e56b1016b7cddaa50618a30639970fa536a6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54671383)</sub>

**Context used:**

- Knowledge Base — [Plugin memory, notes, and context tools](https://app.greptile.com/cortexkit/-/custom-context/knowledge-base/cortexkit/magic-context/-/docs/plugin-memory-and-tools.md)
- Knowledge Base — [Magic Context installation and release flow](https://app.greptile.com/cortexkit/-/custom-context/knowledge-base/cortexkit/magic-context/-/docs/installation-and-release.md)

<!-- /greptile_comment -->