### PR TITLE
feat: support scoped model config overlays

### DIFF
--- a/packages/plugin/src/config/index.test.ts
+++ b/packages/plugin/src/config/index.test.ts
@@ -158,6 +158,7 @@ describe("loadPluginConfig — per-run model overlay", () => {
                     opencode: { model: "overlay/dreamer", fallback_models: ["overlay/fallback"] },
                 },
                 embedding: { provider: "off" },
+                memory: { enabled: false },
             }),
             "utf-8",
         );
@@ -179,9 +180,12 @@ describe("loadPluginConfig — per-run model overlay", () => {
                 fallback_models: ["overlay/fallback"],
             });
             expect(result.embedding.provider).toBe("local");
+            expect(result.memory.enabled).toBe(true);
             expect(result.configWarnings?.join("\n")).toContain(
-                "Ignoring unsupported keys: historian.opencode.prompt",
+                "historian.opencode.prompt",
             );
+            expect(result.configWarnings?.join("\n")).toContain("embedding");
+            expect(result.configWarnings?.join("\n")).toContain("memory");
         } finally {
             rmSync(overlay, { force: true });
         }

--- a/packages/plugin/src/config/index.test.ts
+++ b/packages/plugin/src/config/index.test.ts
@@ -157,6 +157,7 @@ describe("loadPluginConfig — per-run model overlay", () => {
                 dreamer: {
                     opencode: { model: "overlay/dreamer", fallback_models: ["overlay/fallback"] },
                 },
+                sidekick: { model: "overlay/sidekick", variant: "balanced" },
                 embedding: { provider: "off" },
                 memory: { enabled: false },
             }),
@@ -178,6 +179,10 @@ describe("loadPluginConfig — per-run model overlay", () => {
             expect(result.dreamer?.opencode).toMatchObject({
                 model: "overlay/dreamer",
                 fallback_models: ["overlay/fallback"],
+            });
+            expect(result.sidekick).toMatchObject({
+                model: "overlay/sidekick",
+                variant: "balanced",
             });
             expect(result.embedding.provider).toBe("local");
             expect(result.memory.enabled).toBe(true);

--- a/packages/plugin/src/config/index.test.ts
+++ b/packages/plugin/src/config/index.test.ts
@@ -141,6 +141,53 @@ describe("loadPluginConfig — graduated mural config", () => {
     });
 });
 
+describe("loadPluginConfig — per-run model overlay", () => {
+    it("applies only OpenCode model fields from MAGIC_CONTEXT_CONFIG", () => {
+        const overlay = join(tmpdir(), `mc-model-overlay-${Date.now()}.jsonc`);
+        writeFileSync(
+            overlay,
+            JSON.stringify({
+                historian: {
+                    opencode: {
+                        model: "overlay/historian",
+                        variant: "fast",
+                        prompt: "must be ignored",
+                    },
+                },
+                dreamer: {
+                    opencode: { model: "overlay/dreamer", fallback_models: ["overlay/fallback"] },
+                },
+                embedding: { provider: "off" },
+            }),
+            "utf-8",
+        );
+        try {
+            const result = loadWithUserConfig(
+                JSON.stringify({
+                    historian: { opencode: { model: "user/historian" } },
+                    embedding: { provider: "local" },
+                }),
+                { MAGIC_CONTEXT_CONFIG: overlay },
+            );
+
+            expect(result.historian.opencode).toMatchObject({
+                model: "overlay/historian",
+                variant: "fast",
+            });
+            expect(result.dreamer?.opencode).toMatchObject({
+                model: "overlay/dreamer",
+                fallback_models: ["overlay/fallback"],
+            });
+            expect(result.embedding.provider).toBe("local");
+            expect(result.configWarnings?.join("\n")).toContain(
+                "Ignoring unsupported keys: historian.opencode.prompt",
+            );
+        } finally {
+            rmSync(overlay, { force: true });
+        }
+    });
+});
+
 describe("loadPluginConfig — transform mode resolution", () => {
     it("downgrades rust when compaction is off and emits one boot warning", () => {
         const result = loadWithUserConfig(

--- a/packages/plugin/src/config/index.ts
+++ b/packages/plugin/src/config/index.ts
@@ -71,6 +71,11 @@ function loadModelOverlay(): Record<string, unknown> | null {
 
     const overlay: Record<string, unknown> = {};
     const ignored: string[] = [];
+    for (const key of Object.keys(loaded.config)) {
+        if (!(MODEL_OVERLAY_AGENTS as readonly string[]).includes(key)) {
+            ignored.push(key);
+        }
+    }
     for (const agent of MODEL_OVERLAY_AGENTS) {
         const source = loaded.config[agent];
         if (!source || typeof source !== "object" || Array.isArray(source)) {
@@ -78,6 +83,9 @@ function loadModelOverlay(): Record<string, unknown> | null {
             continue;
         }
         const harness = (source as Record<string, unknown>).opencode;
+        for (const key of Object.keys(source as Record<string, unknown>)) {
+            if (key !== "opencode") ignored.push(`${agent}.${key}`);
+        }
         if (!harness || typeof harness !== "object" || Array.isArray(harness)) {
             if (harness !== undefined) ignored.push(`${agent}.opencode`);
             continue;

--- a/packages/plugin/src/config/index.ts
+++ b/packages/plugin/src/config/index.ts
@@ -1,4 +1,5 @@
 import { existsSync } from "node:fs";
+import { resolve as resolvePath } from "node:path";
 
 import { detectConfigFile, isPrototypePollutionKey, parseJsonc } from "../shared/jsonc-parser";
 import { setOutputReserveConfig } from "../shared/models-dev-cache";
@@ -53,6 +54,58 @@ function getUserConfigBasePath(): string {
 
 function getProjectConfigBasePath(directory: string): string {
     return cortexKitProjectConfigBasePath(directory);
+}
+
+const MODEL_OVERLAY_AGENTS = ["historian", "dreamer", "sidekick"] as const;
+const MODEL_OVERLAY_FIELDS = ["model", "fallback_models", "variant"] as const;
+
+function loadModelOverlay(): Record<string, unknown> | null {
+    const configuredPath = process.env.MAGIC_CONTEXT_CONFIG?.trim();
+    if (!configuredPath) return null;
+
+    const loaded = loadConfigFileDetailed(
+        resolvePath(configuredPath),
+        "user",
+    );
+    if (!loaded) return null;
+
+    const overlay: Record<string, unknown> = {};
+    const ignored: string[] = [];
+    for (const agent of MODEL_OVERLAY_AGENTS) {
+        const source = loaded.config[agent];
+        if (!source || typeof source !== "object" || Array.isArray(source)) {
+            if (source !== undefined) ignored.push(agent);
+            continue;
+        }
+        const harness = (source as Record<string, unknown>).opencode;
+        if (!harness || typeof harness !== "object" || Array.isArray(harness)) {
+            if (harness !== undefined) ignored.push(`${agent}.opencode`);
+            continue;
+        }
+        const selected: Record<string, unknown> = {};
+        for (const [key, value] of Object.entries(harness)) {
+            if ((MODEL_OVERLAY_FIELDS as readonly string[]).includes(key)) {
+                selected[key] = value;
+            } else {
+                ignored.push(`${agent}.opencode.${key}`);
+            }
+        }
+        if (Object.keys(selected).length > 0) {
+            overlay[agent] = { opencode: selected };
+        }
+    }
+
+    if (loaded.warnings.length > 0 || ignored.length > 0) {
+        overlay.configWarnings = [
+            ...loaded.warnings.map((warning) => `[model overlay] ${warning}`),
+            ...(ignored.length > 0
+                ? [
+                      `[model overlay] Ignoring unsupported keys: ${ignored.join(", ")}. Only OpenCode model, fallback_models, and variant fields are supported.`,
+                  ]
+                : []),
+        ];
+    }
+    return overlay;
 }
 
 interface LegacyReadFallback {
@@ -600,6 +653,14 @@ export function loadPluginConfigDetailed(directory: string): LoadResultDetailed 
         })) {
             allWarnings.push(`[project config] ${warning}`);
         }
+    }
+
+    const modelOverlay = loadModelOverlay();
+    if (modelOverlay) {
+        const overlayWarnings = modelOverlay.configWarnings;
+        delete modelOverlay.configWarnings;
+        mergedRaw = deepMergeRawConfig(mergedRaw, modelOverlay);
+        if (overlayWarnings) allWarnings.push(...overlayWarnings);
     }
 
     const recoveredTopLevelKeys: string[] = [];

--- a/packages/plugin/src/config/index.ts
+++ b/packages/plugin/src/config/index.ts
@@ -82,12 +82,16 @@ function loadModelOverlay(): Record<string, unknown> | null {
             if (source !== undefined) ignored.push(agent);
             continue;
         }
-        const harness = (source as Record<string, unknown>).opencode;
-        for (const key of Object.keys(source as Record<string, unknown>)) {
-            if (key !== "opencode") ignored.push(`${agent}.${key}`);
+        const sourceRecord = source as Record<string, unknown>;
+        const isFlatSidekick = agent === "sidekick";
+        const harness = isFlatSidekick ? sourceRecord : sourceRecord.opencode;
+        for (const key of Object.keys(sourceRecord)) {
+            if (isFlatSidekick ? !(MODEL_OVERLAY_FIELDS as readonly string[]).includes(key) : key !== "opencode") {
+                ignored.push(`${agent}.${key}`);
+            }
         }
         if (!harness || typeof harness !== "object" || Array.isArray(harness)) {
-            if (harness !== undefined) ignored.push(`${agent}.opencode`);
+            if (harness !== undefined) ignored.push(`${agent}${isFlatSidekick ? "" : ".opencode"}`);
             continue;
         }
         const selected: Record<string, unknown> = {};
@@ -99,7 +103,7 @@ function loadModelOverlay(): Record<string, unknown> | null {
             }
         }
         if (Object.keys(selected).length > 0) {
-            overlay[agent] = { opencode: selected };
+            overlay[agent] = isFlatSidekick ? selected : { opencode: selected };
         }
     }
 


### PR DESCRIPTION
## Summary

Closes #354.

This PR adds an optional `MAGIC_CONTEXT_CONFIG` JSONC overlay for per-run model selection across historian, dreamer, and sidekick.

- Supports `model`, `fallback_models`, and `variant` overrides only.
- Uses the existing nested `opencode` shape for historian and dreamer, and the flat model shape for sidekick.
- Reports unsupported top-level, harness, and field-level keys instead of silently ignoring them.
- Preserves shared embedding, storage, memory, compaction, prompt-surface, and threshold settings.
- Adds regression coverage for model overrides, ignored keys, flat sidekick configuration, and preservation of durable settings.

Existing behavior is unchanged when `MAGIC_CONTEXT_CONFIG` is unset.

## Verification

- `bun test packages/plugin/src/config/index.test.ts` — passed (53 tests, 0 failures).
- `git diff --check` — passed.
- Typecheck and lint were not completed because dependency installation did not finish and the required tools were unavailable.

## Status / Design Note

The implementation follows the scoped two-profile model-selection workflow discussed for #354. The PR is currently on hold pending the maintainer's design discussion about the configuration mechanism and profile/process behavior.

The latest automated review also identified follow-up coverage/robustness questions around invalid supported overlay values replacing valid base settings, and duplicate/mislabelled warnings for unsupported flat sidekick fields. These should be resolved against the final direction agreed in #354 before merging.





<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adds a `MAGIC_CONTEXT_CONFIG` JSONC overlay limited to historian, dreamer, and sidekick model-selection fields.

- Loads the optional overlay after user, profile, and project configuration resolution.
- Supports nested OpenCode settings for historian and dreamer and flat settings for sidekick.
- Reports unsupported overlay keys and adds regression coverage for valid overrides and preservation of unrelated settings.
</details>


<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because invalid supported overlay values can still erase valid base model selections.

Supported overlay fields are copied without value validation and merged over the base configuration before schema recovery; recovery can remove the invalid replacement but cannot restore the valid model, fallback chain, or variant that it overwrote.

**Files Needing Attention:** packages/plugin/src/config/index.ts

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/plugin/src/config/index.ts | Adds loading, filtering, warning generation, and final merging for the scoped model overlay. |
| packages/plugin/src/config/index.test.ts | Adds end-to-end coverage for valid historian, dreamer, and flat sidekick overlays while checking preservation of unrelated configuration. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  U[User configuration] --> M[Merge profiles and project configuration]
  P[Project configuration] --> M
  R[Selected profile] --> M
  E[MAGIC_CONTEXT_CONFIG] --> O[Select supported model fields]
  O --> M2[Apply model overlay]
  M --> M2
  M2 --> V[Schema validation and recovery]
  V --> C[Effective plugin configuration]
```
</details>

<sub>Reviews (5): Last reviewed commit: ["Merge branch &#39;master&#39; into feat/config-e..."](https://github.com/cortexkit/magic-context/commit/8efa9880b8aca63a70ccf37548db12ae37aa80d3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55843750)</sub>

**Context used:**

- Knowledge Base — [Configuration and harness compatibility](https://app.greptile.com/cortexkit/-/custom-context/knowledge-base/cortexkit/magic-context/-/docs/configuration-and-compatibility.md)
- Knowledge Base — [Configuration resolution and migration](https://app.greptile.com/cortexkit/-/custom-context/knowledge-base/cortexkit/magic-context/-/docs/configuration-resolution.md)

<!-- /greptile_comment -->