### PR TITLE
fix(test): restore per-test DB isolation broken by storage-dir precedence

### DIFF
--- a/packages/plugin/src/features/magic-context/compaction-marker.test.ts
+++ b/packages/plugin/src/features/magic-context/compaction-marker.test.ts
@@ -15,11 +15,13 @@ import {
 
 const tempDirs: string[] = [];
 const originalXdgDataHome = process.env.XDG_DATA_HOME;
+const originalTestDataDir = process.env.MAGIC_CONTEXT_TEST_DATA_DIR;
 
 function useTempDataHome(prefix: string): string {
     const dir = mkdtempSync(join(tmpdir(), prefix));
     tempDirs.push(dir);
     process.env.XDG_DATA_HOME = dir;
+    process.env.MAGIC_CONTEXT_TEST_DATA_DIR = dir;
     mkdirSync(join(dir, "opencode"), { recursive: true });
     return dir;
 }
@@ -51,6 +53,8 @@ function insertMessage(
 afterEach(() => {
     closeCompactionMarkerDb();
     process.env.XDG_DATA_HOME = originalXdgDataHome;
+    if (originalTestDataDir === undefined) delete process.env.MAGIC_CONTEXT_TEST_DATA_DIR;
+    else process.env.MAGIC_CONTEXT_TEST_DATA_DIR = originalTestDataDir;
     for (const dir of tempDirs) {
         rmSync(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
     }

--- a/packages/plugin/src/features/magic-context/compartment-storage-v6.test.ts
+++ b/packages/plugin/src/features/magic-context/compartment-storage-v6.test.ts
@@ -6,11 +6,13 @@ import { appendCompartments, getCompartmentsByEndMessageId } from "./compartment
 import { closeDatabase, openDatabase } from "./storage";
 
 const tempDirs: string[] = [];
+const originalTestDataDir = process.env.MAGIC_CONTEXT_TEST_DATA_DIR;
 
 function useTempDataHome(prefix: string): string {
     const dir = mkdtempSync(join(tmpdir(), prefix));
     tempDirs.push(dir);
     process.env.XDG_DATA_HOME = dir;
+    process.env.MAGIC_CONTEXT_TEST_DATA_DIR = dir;
     return dir;
 }
 
@@ -25,6 +27,8 @@ afterEach(() => {
     }
     tempDirs.length = 0;
     process.env.XDG_DATA_HOME = undefined;
+    if (originalTestDataDir === undefined) delete process.env.MAGIC_CONTEXT_TEST_DATA_DIR;
+    else process.env.MAGIC_CONTEXT_TEST_DATA_DIR = originalTestDataDir;
 });
 
 describe("getCompartmentsByEndMessageId (plan v6 §5)", () => {

--- a/packages/plugin/src/features/magic-context/compression-depth-storage.test.ts
+++ b/packages/plugin/src/features/magic-context/compression-depth-storage.test.ts
@@ -15,6 +15,7 @@ import {
 
 const tempDirs: string[] = [];
 const originalXdgDataHome = process.env.XDG_DATA_HOME;
+const originalTestDataDir = process.env.MAGIC_CONTEXT_TEST_DATA_DIR;
 
 function makeTempDir(prefix: string): string {
     const dir = mkdtempSync(join(tmpdir(), prefix));
@@ -23,12 +24,16 @@ function makeTempDir(prefix: string): string {
 }
 
 function useTempDataHome(prefix: string): void {
-    process.env.XDG_DATA_HOME = makeTempDir(prefix);
+    const dir = makeTempDir(prefix);
+    process.env.XDG_DATA_HOME = dir;
+    process.env.MAGIC_CONTEXT_TEST_DATA_DIR = dir;
 }
 
 afterEach(() => {
     closeDatabase();
     process.env.XDG_DATA_HOME = originalXdgDataHome;
+    if (originalTestDataDir === undefined) delete process.env.MAGIC_CONTEXT_TEST_DATA_DIR;
+    else process.env.MAGIC_CONTEXT_TEST_DATA_DIR = originalTestDataDir;
 
     for (const dir of tempDirs) {
         try {

--- a/packages/plugin/src/features/magic-context/migrations-v11.test.ts
+++ b/packages/plugin/src/features/magic-context/migrations-v11.test.ts
@@ -19,11 +19,13 @@ const TODO_COLUMNS = [
 ];
 
 const tempDirs: string[] = [];
+const originalTestDataDir = process.env.MAGIC_CONTEXT_TEST_DATA_DIR;
 
 function useTempDataHome(prefix: string): string {
     const dir = mkdtempSync(join(tmpdir(), prefix));
     tempDirs.push(dir);
     process.env.XDG_DATA_HOME = dir;
+    process.env.MAGIC_CONTEXT_TEST_DATA_DIR = dir;
     return dir;
 }
 
@@ -38,6 +40,8 @@ afterEach(() => {
     }
     tempDirs.length = 0;
     process.env.XDG_DATA_HOME = undefined;
+    if (originalTestDataDir === undefined) delete process.env.MAGIC_CONTEXT_TEST_DATA_DIR;
+    else process.env.MAGIC_CONTEXT_TEST_DATA_DIR = originalTestDataDir;
 });
 
 describe("migration v11 — todo state synthesis schema", () => {

--- a/packages/plugin/src/features/magic-context/migrations-v12.test.ts
+++ b/packages/plugin/src/features/magic-context/migrations-v12.test.ts
@@ -7,11 +7,13 @@ import { runMigrations } from "./migrations";
 import { closeDatabase, initializeDatabase, openDatabase } from "./storage-db";
 
 const tempDirs: string[] = [];
+const originalTestDataDir = process.env.MAGIC_CONTEXT_TEST_DATA_DIR;
 
 function useTempDataHome(prefix: string): string {
     const dir = mkdtempSync(join(tmpdir(), prefix));
     tempDirs.push(dir);
     process.env.XDG_DATA_HOME = dir;
+    process.env.MAGIC_CONTEXT_TEST_DATA_DIR = dir;
     return dir;
 }
 
@@ -30,6 +32,8 @@ afterEach(() => {
     }
     tempDirs.length = 0;
     process.env.XDG_DATA_HOME = undefined;
+    if (originalTestDataDir === undefined) delete process.env.MAGIC_CONTEXT_TEST_DATA_DIR;
+    else process.env.MAGIC_CONTEXT_TEST_DATA_DIR = originalTestDataDir;
 });
 
 describe("migration v12 — FK cascades and orphan cleanup", () => {

--- a/packages/plugin/src/features/magic-context/migrations-v13.test.ts
+++ b/packages/plugin/src/features/magic-context/migrations-v13.test.ts
@@ -12,11 +12,13 @@ import {
 } from "./storage-meta-persisted";
 
 const tempDirs: string[] = [];
+const originalTestDataDir = process.env.MAGIC_CONTEXT_TEST_DATA_DIR;
 
 function useTempDataHome(prefix: string): string {
     const dir = mkdtempSync(join(tmpdir(), prefix));
     tempDirs.push(dir);
     process.env.XDG_DATA_HOME = dir;
+    process.env.MAGIC_CONTEXT_TEST_DATA_DIR = dir;
     return dir;
 }
 
@@ -31,6 +33,8 @@ afterEach(() => {
     }
     tempDirs.length = 0;
     process.env.XDG_DATA_HOME = undefined;
+    if (originalTestDataDir === undefined) delete process.env.MAGIC_CONTEXT_TEST_DATA_DIR;
+    else process.env.MAGIC_CONTEXT_TEST_DATA_DIR = originalTestDataDir;
 });
 
 describe("migration v13 — pending_compaction_marker_state schema", () => {

--- a/packages/plugin/src/features/magic-context/migrations-v16.test.ts
+++ b/packages/plugin/src/features/magic-context/migrations-v16.test.ts
@@ -5,11 +5,13 @@ import { join } from "node:path";
 import { closeDatabase, openDatabase } from "./storage";
 
 const tempDirs: string[] = [];
+const originalTestDataDir = process.env.MAGIC_CONTEXT_TEST_DATA_DIR;
 
 function useTempDataHome(prefix: string): void {
     const dir = mkdtempSync(join(tmpdir(), prefix));
     tempDirs.push(dir);
     process.env.XDG_DATA_HOME = dir;
+    process.env.MAGIC_CONTEXT_TEST_DATA_DIR = dir;
 }
 
 afterEach(() => {
@@ -23,6 +25,8 @@ afterEach(() => {
     }
     tempDirs.length = 0;
     process.env.XDG_DATA_HOME = undefined;
+    if (originalTestDataDir === undefined) delete process.env.MAGIC_CONTEXT_TEST_DATA_DIR;
+    else process.env.MAGIC_CONTEXT_TEST_DATA_DIR = originalTestDataDir;
 });
 
 describe("migration v16 — context-limit cache regression sentinels", () => {

--- a/packages/plugin/src/features/magic-context/migrations-v18-pi-marker.test.ts
+++ b/packages/plugin/src/features/magic-context/migrations-v18-pi-marker.test.ts
@@ -12,11 +12,13 @@ import {
 } from "./storage-meta-persisted";
 
 const tempDirs: string[] = [];
+const originalTestDataDir = process.env.MAGIC_CONTEXT_TEST_DATA_DIR;
 
 function useTempDataHome(prefix: string): void {
     const dir = mkdtempSync(join(tmpdir(), prefix));
     tempDirs.push(dir);
     process.env.XDG_DATA_HOME = dir;
+    process.env.MAGIC_CONTEXT_TEST_DATA_DIR = dir;
 }
 
 afterEach(() => {
@@ -30,6 +32,8 @@ afterEach(() => {
     }
     tempDirs.length = 0;
     process.env.XDG_DATA_HOME = undefined;
+    if (originalTestDataDir === undefined) delete process.env.MAGIC_CONTEXT_TEST_DATA_DIR;
+    else process.env.MAGIC_CONTEXT_TEST_DATA_DIR = originalTestDataDir;
 });
 
 function payload(overrides: Partial<PendingPiCompactionMarker> = {}): PendingPiCompactionMarker {

--- a/packages/plugin/src/features/magic-context/storage-db.test.ts
+++ b/packages/plugin/src/features/magic-context/storage-db.test.ts
@@ -49,6 +49,7 @@ import { SESSION_SCOPED_TABLES } from "./storage-session-tables";
 
 const tempDirs: string[] = [];
 const originalXdgDataHome = process.env.XDG_DATA_HOME;
+const originalTestDataDir = process.env.MAGIC_CONTEXT_TEST_DATA_DIR;
 const originalStorageDir = process.env.MAGIC_CONTEXT_STORAGE_DIR;
 const originalNodeEnv = process.env.NODE_ENV;
 
@@ -111,6 +112,8 @@ afterEach(() => {
     __resetRpcIdentityTestHooks();
     __resetStoragePrivatePermissionEnforcementForTests();
     process.env.XDG_DATA_HOME = originalXdgDataHome;
+    if (originalTestDataDir === undefined) delete process.env.MAGIC_CONTEXT_TEST_DATA_DIR;
+    else process.env.MAGIC_CONTEXT_TEST_DATA_DIR = originalTestDataDir;
     if (originalStorageDir === undefined) delete process.env.MAGIC_CONTEXT_STORAGE_DIR;
     else process.env.MAGIC_CONTEXT_STORAGE_DIR = originalStorageDir;
     if (originalNodeEnv === undefined) delete process.env.NODE_ENV;

--- a/packages/plugin/src/features/magic-context/storage.test.ts
+++ b/packages/plugin/src/features/magic-context/storage.test.ts
@@ -49,10 +49,13 @@ import { ensureColumn, initializeDatabase } from "./storage-db";
 
 const tempDirs: string[] = [];
 const originalXdgDataHome = process.env.XDG_DATA_HOME;
+const originalTestDataDir = process.env.MAGIC_CONTEXT_TEST_DATA_DIR;
 
 afterEach(() => {
     closeDatabase();
     process.env.XDG_DATA_HOME = originalXdgDataHome;
+    if (originalTestDataDir === undefined) delete process.env.MAGIC_CONTEXT_TEST_DATA_DIR;
+    else process.env.MAGIC_CONTEXT_TEST_DATA_DIR = originalTestDataDir;
 
     for (const dir of tempDirs) {
         try {
@@ -73,6 +76,7 @@ function makeTempDir(prefix: string): string {
 function useTempDataHome(prefix: string): string {
     const dataHome = makeTempDir(prefix);
     process.env.XDG_DATA_HOME = dataHome;
+    process.env.MAGIC_CONTEXT_TEST_DATA_DIR = dataHome;
     return dataHome;
 }
 

--- a/packages/plugin/src/features/magic-context/window-report-ledger.test.ts
+++ b/packages/plugin/src/features/magic-context/window-report-ledger.test.ts
@@ -25,11 +25,14 @@ import {
 
 const temporaryPaths: string[] = [];
 const originalXdgDataHome = process.env.XDG_DATA_HOME;
+const originalTestDataDir = process.env.MAGIC_CONTEXT_TEST_DATA_DIR;
 
 afterEach(() => {
     closeDatabase();
     __resetWindowReportLedgerDiagnosticsForTests();
     process.env.XDG_DATA_HOME = originalXdgDataHome;
+    if (originalTestDataDir === undefined) delete process.env.MAGIC_CONTEXT_TEST_DATA_DIR;
+    else process.env.MAGIC_CONTEXT_TEST_DATA_DIR = originalTestDataDir;
     for (const temporaryPath of temporaryPaths.splice(0)) {
         rmSync(temporaryPath, { recursive: true, force: true });
     }
@@ -39,6 +42,7 @@ function useTemporaryDataHome(): void {
     const directory = mkdtempSync(join(tmpdir(), "mc-window-report-"));
     temporaryPaths.push(directory);
     process.env.XDG_DATA_HOME = directory;
+    process.env.MAGIC_CONTEXT_TEST_DATA_DIR = directory;
 }
 
 describe("window report ledger", () => {

--- a/packages/plugin/src/hooks/magic-context/apply-operations.tool-drop.test.ts
+++ b/packages/plugin/src/hooks/magic-context/apply-operations.tool-drop.test.ts
@@ -24,10 +24,13 @@ import {
 
 const tempDirs: string[] = [];
 const originalXdgDataHome = process.env.XDG_DATA_HOME;
+const originalTestDataDir = process.env.MAGIC_CONTEXT_TEST_DATA_DIR;
 
 afterEach(() => {
     closeDatabase();
     process.env.XDG_DATA_HOME = originalXdgDataHome;
+    if (originalTestDataDir === undefined) delete process.env.MAGIC_CONTEXT_TEST_DATA_DIR;
+    else process.env.MAGIC_CONTEXT_TEST_DATA_DIR = originalTestDataDir;
     for (const dir of tempDirs) {
         try {
             rmSync(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
@@ -42,6 +45,7 @@ function useTempDataHome(prefix: string): void {
     const dir = mkdtempSync(join(tmpdir(), prefix));
     tempDirs.push(dir);
     process.env.XDG_DATA_HOME = dir;
+    process.env.MAGIC_CONTEXT_TEST_DATA_DIR = dir;
 }
 
 /**

--- a/packages/plugin/src/hooks/magic-context/channel2-delivery.test.ts
+++ b/packages/plugin/src/hooks/magic-context/channel2-delivery.test.ts
@@ -19,11 +19,14 @@ import { maybeDeliverChannel2 } from "./channel2-delivery";
 import { closeReadOnlySessionDb } from "./read-session-db";
 
 const openCodeDbs: Database[] = [];
+const originalTestDataDir = process.env.MAGIC_CONTEXT_TEST_DATA_DIR;
 
 function useTempDataHome(prefix: string): void {
     const { mkdtempSync } = require("node:fs");
     const { tmpdir } = require("node:os");
-    process.env.XDG_DATA_HOME = mkdtempSync(join(tmpdir(), prefix));
+    const dir = mkdtempSync(join(tmpdir(), prefix));
+    process.env.XDG_DATA_HOME = dir;
+    process.env.MAGIC_CONTEXT_TEST_DATA_DIR = dir;
 }
 
 function createOpenCodeAssistantTail(sessionId: string, finish: string): Database {
@@ -50,6 +53,8 @@ afterEach(() => {
     closeReadOnlySessionDb();
     closeDatabase();
     mock.restore();
+    if (originalTestDataDir === undefined) delete process.env.MAGIC_CONTEXT_TEST_DATA_DIR;
+    else process.env.MAGIC_CONTEXT_TEST_DATA_DIR = originalTestDataDir;
 });
 
 /**

--- a/packages/plugin/src/hooks/magic-context/compaction-marker-consistency.test.ts
+++ b/packages/plugin/src/hooks/magic-context/compaction-marker-consistency.test.ts
@@ -12,11 +12,13 @@ import { checkCompactionMarkerConsistency } from "./compaction-marker-manager";
 
 const tempDirs: string[] = [];
 const originalXdgDataHome = process.env.XDG_DATA_HOME;
+const originalTestDataDir = process.env.MAGIC_CONTEXT_TEST_DATA_DIR;
 
 function useTempDataHome(prefix: string): string {
     const dir = mkdtempSync(join(tmpdir(), prefix));
     tempDirs.push(dir);
     process.env.XDG_DATA_HOME = dir;
+    process.env.MAGIC_CONTEXT_TEST_DATA_DIR = dir;
     // Match the getDataDir() layout the plugin expects. opencode.db lives
     // under opencode/, while magic-context's own DB now lives at the shared
     // cortexkit path. Create both parent directories so the OpenCode-side DB
@@ -59,6 +61,8 @@ function insertPart(db: Database, id: string): void {
 afterEach(() => {
     closeDatabase();
     process.env.XDG_DATA_HOME = originalXdgDataHome;
+    if (originalTestDataDir === undefined) delete process.env.MAGIC_CONTEXT_TEST_DATA_DIR;
+    else process.env.MAGIC_CONTEXT_TEST_DATA_DIR = originalTestDataDir;
     for (const dir of tempDirs) {
         try {
             rmSync(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });

--- a/packages/plugin/src/hooks/magic-context/compaction-marker-manager.test.ts
+++ b/packages/plugin/src/hooks/magic-context/compaction-marker-manager.test.ts
@@ -47,11 +47,13 @@ import { reconcileMarkerRepresentation } from "./transform-postprocess-phase";
 
 const tempDirs: string[] = [];
 const originalXdgDataHome = process.env.XDG_DATA_HOME;
+const originalTestDataDir = process.env.MAGIC_CONTEXT_TEST_DATA_DIR;
 
 function useTempDataHome(prefix: string): string {
     const dir = mkdtempSync(join(tmpdir(), prefix));
     tempDirs.push(dir);
     process.env.XDG_DATA_HOME = dir;
+    process.env.MAGIC_CONTEXT_TEST_DATA_DIR = dir;
     mkdirSync(join(dir, "opencode"), { recursive: true });
     mkdirSync(join(dir, "cortexkit", "magic-context"), { recursive: true });
     return dir;
@@ -188,6 +190,8 @@ afterEach(() => {
     closeCompactionMarkerConnection();
     closeDatabase();
     process.env.XDG_DATA_HOME = originalXdgDataHome;
+    if (originalTestDataDir === undefined) delete process.env.MAGIC_CONTEXT_TEST_DATA_DIR;
+    else process.env.MAGIC_CONTEXT_TEST_DATA_DIR = originalTestDataDir;
     for (const dir of tempDirs) {
         try {
             rmSync(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });

--- a/packages/plugin/src/hooks/magic-context/compaction-off-transition.test.ts
+++ b/packages/plugin/src/hooks/magic-context/compaction-off-transition.test.ts
@@ -52,12 +52,15 @@ import {
 
 const tempDirs: string[] = [];
 const originalXdgDataHome = process.env.XDG_DATA_HOME;
+const originalTestDataDir = process.env.MAGIC_CONTEXT_TEST_DATA_DIR;
 
 afterEach(() => {
     closeCompactionMarkerDb();
     closeDatabase();
     if (originalXdgDataHome === undefined) delete process.env.XDG_DATA_HOME;
     else process.env.XDG_DATA_HOME = originalXdgDataHome;
+    if (originalTestDataDir === undefined) delete process.env.MAGIC_CONTEXT_TEST_DATA_DIR;
+    else process.env.MAGIC_CONTEXT_TEST_DATA_DIR = originalTestDataDir;
     for (const dir of tempDirs) {
         try {
             rmSync(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
@@ -72,6 +75,7 @@ function useTempDataHome(prefix: string): void {
     const dir = mkdtempSync(join(tmpdir(), prefix));
     tempDirs.push(dir);
     process.env.XDG_DATA_HOME = dir;
+    process.env.MAGIC_CONTEXT_TEST_DATA_DIR = dir;
 }
 
 // ── OpenCode-compatible DB fixture ───────────────────────────────

--- a/packages/plugin/src/hooks/magic-context/compartment-runner-drop-queue.test.ts
+++ b/packages/plugin/src/hooks/magic-context/compartment-runner-drop-queue.test.ts
@@ -28,6 +28,7 @@ import type { RawMessage } from "./read-session-raw";
 
 const tempDirs: string[] = [];
 const originalXdgDataHome = process.env.XDG_DATA_HOME;
+const originalTestDataDir = process.env.MAGIC_CONTEXT_TEST_DATA_DIR;
 
 beforeEach(() => {
     closeDatabase();
@@ -36,6 +37,8 @@ beforeEach(() => {
 afterEach(() => {
     closeDatabase();
     process.env.XDG_DATA_HOME = originalXdgDataHome;
+    if (originalTestDataDir === undefined) delete process.env.MAGIC_CONTEXT_TEST_DATA_DIR;
+    else process.env.MAGIC_CONTEXT_TEST_DATA_DIR = originalTestDataDir;
     for (const dir of tempDirs) {
         try {
             rmSync(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
@@ -50,6 +53,7 @@ function useTempDataHome(prefix: string): void {
     const dir = mkdtempSync(join(tmpdir(), prefix));
     tempDirs.push(dir);
     process.env.XDG_DATA_HOME = dir;
+    process.env.MAGIC_CONTEXT_TEST_DATA_DIR = dir;
 }
 
 function makeRawMessages(messages: RawMessage[]) {

--- a/packages/plugin/src/hooks/magic-context/compartment-runner-timeout.test.ts
+++ b/packages/plugin/src/hooks/magic-context/compartment-runner-timeout.test.ts
@@ -13,10 +13,13 @@ import { executeContextRecomp, runCompartmentAgent } from "./compartment-runner"
 
 const tempDirs: string[] = [];
 const originalXdgDataHome = process.env.XDG_DATA_HOME;
+const originalTestDataDir = process.env.MAGIC_CONTEXT_TEST_DATA_DIR;
 
 afterEach(() => {
     closeDatabase();
     process.env.XDG_DATA_HOME = originalXdgDataHome;
+    if (originalTestDataDir === undefined) delete process.env.MAGIC_CONTEXT_TEST_DATA_DIR;
+    else process.env.MAGIC_CONTEXT_TEST_DATA_DIR = originalTestDataDir;
 
     for (const dir of tempDirs) {
         try {
@@ -135,6 +138,7 @@ function useTempDataHome(prefix: string): void {
     const dir = mkdtempSync(join(tmpdir(), prefix));
     tempDirs.push(dir);
     process.env.XDG_DATA_HOME = dir;
+    process.env.MAGIC_CONTEXT_TEST_DATA_DIR = dir;
 }
 
 function createOpenCodeDb(

--- a/packages/plugin/src/hooks/magic-context/compartment-runner.test.ts
+++ b/packages/plugin/src/hooks/magic-context/compartment-runner.test.ts
@@ -49,6 +49,7 @@ import { tagMessages } from "./tag-messages";
 
 const tempDirs: string[] = [];
 const originalXdgDataHome = process.env.XDG_DATA_HOME;
+const originalTestDataDir = process.env.MAGIC_CONTEXT_TEST_DATA_DIR;
 
 async function runCompartmentAgentWithLease(
     deps: Parameters<typeof runCompartmentAgent>[0],
@@ -65,6 +66,8 @@ async function runCompartmentAgentWithLease(
 afterEach(() => {
     closeDatabase();
     process.env.XDG_DATA_HOME = originalXdgDataHome;
+    if (originalTestDataDir === undefined) delete process.env.MAGIC_CONTEXT_TEST_DATA_DIR;
+    else process.env.MAGIC_CONTEXT_TEST_DATA_DIR = originalTestDataDir;
 
     for (const dir of tempDirs) {
         try {
@@ -1000,6 +1003,7 @@ function useTempDataHome(prefix: string): void {
     const dir = mkdtempSync(join(tmpdir(), prefix));
     tempDirs.push(dir);
     process.env.XDG_DATA_HOME = dir;
+    process.env.MAGIC_CONTEXT_TEST_DATA_DIR = dir;
 }
 
 function createOpenCodeDb(

--- a/packages/plugin/src/hooks/magic-context/compartment-trigger.test.ts
+++ b/packages/plugin/src/hooks/magic-context/compartment-trigger.test.ts
@@ -19,10 +19,13 @@ import type { RawMessage } from "./read-session-raw";
 
 const tempDirs: string[] = [];
 const originalXdgDataHome = process.env.XDG_DATA_HOME;
+const originalTestDataDir = process.env.MAGIC_CONTEXT_TEST_DATA_DIR;
 
 afterEach(() => {
     closeDatabase();
     process.env.XDG_DATA_HOME = originalXdgDataHome;
+    if (originalTestDataDir === undefined) delete process.env.MAGIC_CONTEXT_TEST_DATA_DIR;
+    else process.env.MAGIC_CONTEXT_TEST_DATA_DIR = originalTestDataDir;
     for (const dir of tempDirs) {
         try {
             rmSync(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
@@ -37,6 +40,7 @@ function useTempDataHome(prefix: string): void {
     const dir = mkdtempSync(join(tmpdir(), prefix));
     tempDirs.push(dir);
     process.env.XDG_DATA_HOME = dir;
+    process.env.MAGIC_CONTEXT_TEST_DATA_DIR = dir;
 }
 
 function createOpenCodeDb(

--- a/packages/plugin/src/hooks/magic-context/degraded-reanchor.test.ts
+++ b/packages/plugin/src/hooks/magic-context/degraded-reanchor.test.ts
@@ -46,6 +46,7 @@ const SESSION_ID = "ses_degraded_reanchor";
 
 const tempDirs: string[] = [];
 const originalXdgDataHome = process.env.XDG_DATA_HOME;
+const originalTestDataDir = process.env.MAGIC_CONTEXT_TEST_DATA_DIR;
 const originalXdgCacheHome = process.env.XDG_CACHE_HOME;
 
 let db: Database;
@@ -55,6 +56,7 @@ function useTempDataHome(prefix: string): string {
     const dir = mkdtempSync(join(tmpdir(), prefix));
     tempDirs.push(dir);
     process.env.XDG_DATA_HOME = dir;
+    process.env.MAGIC_CONTEXT_TEST_DATA_DIR = dir;
     process.env.XDG_CACHE_HOME = dir;
     mkdirSync(join(dir, "opencode"), { recursive: true });
     return dir;
@@ -165,6 +167,8 @@ afterEach(() => {
     }
     if (originalXdgDataHome === undefined) delete process.env.XDG_DATA_HOME;
     else process.env.XDG_DATA_HOME = originalXdgDataHome;
+    if (originalTestDataDir === undefined) delete process.env.MAGIC_CONTEXT_TEST_DATA_DIR;
+    else process.env.MAGIC_CONTEXT_TEST_DATA_DIR = originalTestDataDir;
     if (originalXdgCacheHome === undefined) delete process.env.XDG_CACHE_HOME;
     else process.env.XDG_CACHE_HOME = originalXdgCacheHome;
 });

--- a/packages/plugin/src/hooks/magic-context/event-handler.test.ts
+++ b/packages/plugin/src/hooks/magic-context/event-handler.test.ts
@@ -52,6 +52,7 @@ type ContextUsageCacheEntry = {
 
 const tempDirs: string[] = [];
 const originalXdgDataHome = process.env.XDG_DATA_HOME;
+const originalTestDataDir = process.env.MAGIC_CONTEXT_TEST_DATA_DIR;
 
 afterEach(() => {
     __resetMessageIndexAsyncForTests();
@@ -59,6 +60,8 @@ afterEach(() => {
     closeDatabase();
     clearModelsDevCache();
     process.env.XDG_DATA_HOME = originalXdgDataHome;
+    if (originalTestDataDir === undefined) delete process.env.MAGIC_CONTEXT_TEST_DATA_DIR;
+    else process.env.MAGIC_CONTEXT_TEST_DATA_DIR = originalTestDataDir;
 
     for (const dir of tempDirs) {
         try {
@@ -77,7 +80,9 @@ function makeTempDir(prefix: string): string {
 }
 
 function useTempDataHome(prefix: string): void {
-    process.env.XDG_DATA_HOME = makeTempDir(prefix);
+    const dir = makeTempDir(prefix);
+    process.env.XDG_DATA_HOME = dir;
+    process.env.MAGIC_CONTEXT_TEST_DATA_DIR = dir;
 }
 
 function resolveContextLimit(): number {

--- a/packages/plugin/src/hooks/magic-context/hook.test.ts
+++ b/packages/plugin/src/hooks/magic-context/hook.test.ts
@@ -80,6 +80,7 @@ class HookFakeEmbeddingProvider implements EmbeddingProvider {
 
 const tempDirs: string[] = [];
 const originalXdgDataHome = process.env.XDG_DATA_HOME;
+const originalTestDataDir = process.env.MAGIC_CONTEXT_TEST_DATA_DIR;
 
 function makeTempDir(prefix: string): string {
     const dir = mkdtempSync(join(tmpdir(), prefix));
@@ -96,6 +97,8 @@ afterEach(() => {
     closeReadOnlySessionDb();
     closeDatabase();
     process.env.XDG_DATA_HOME = originalXdgDataHome;
+    if (originalTestDataDir === undefined) delete process.env.MAGIC_CONTEXT_TEST_DATA_DIR;
+    else process.env.MAGIC_CONTEXT_TEST_DATA_DIR = originalTestDataDir;
 
     for (const dir of tempDirs) {
         try {
@@ -246,7 +249,9 @@ function countIndexedHookMessage(sessionId: string, messageId: string): number {
 
 describe("magic-context hook", () => {
     it("constructs with directory fallback when load-time identity resolution throws", () => {
-        process.env.XDG_DATA_HOME = makeTempDir("hook-identity-fallback-data-");
+        const dataHome = makeTempDir("hook-identity-fallback-data-");
+        process.env.XDG_DATA_HOME = dataHome;
+        process.env.MAGIC_CONTEXT_TEST_DATA_DIR = dataHome;
         const projectDir = makeTempDir("hook-identity-fallback-project-");
         mkdirSync(join(projectDir, ".git"));
         __setProjectIdentityTestHooks({
@@ -263,7 +268,9 @@ describe("magic-context hook", () => {
     });
 
     it("constructs and resolves a project when sandbox policy denies realpath for the home directory", () => {
-        process.env.XDG_DATA_HOME = makeTempDir("hook-realpath-sandbox-data-");
+        const dataHome = makeTempDir("hook-realpath-sandbox-data-");
+        process.env.XDG_DATA_HOME = dataHome;
+        process.env.MAGIC_CONTEXT_TEST_DATA_DIR = dataHome;
         const projectDir = makeTempDir("hook-realpath-sandbox-project-");
         const deniedHome = makeTempDir("hook-realpath-sandbox-home-");
         const originalNative = realpathSync.native;
@@ -291,7 +298,9 @@ describe("magic-context hook", () => {
     });
 
     it("rehydrates pending marker sessions into both deferred signal sets", () => {
-        process.env.XDG_DATA_HOME = makeTempDir("hook-marker-rehydrate-");
+        const dataHome = makeTempDir("hook-marker-rehydrate-");
+        process.env.XDG_DATA_HOME = dataHome;
+        process.env.MAGIC_CONTEXT_TEST_DATA_DIR = dataHome;
         const db = openDatabase();
         const sessionId = "ses-marker-rehydrate";
         setPendingCompactionMarkerState(db, sessionId, {
@@ -310,7 +319,9 @@ describe("magic-context hook", () => {
     });
 
     it("indexes terminal message.updated events asynchronously", async () => {
-        process.env.XDG_DATA_HOME = makeTempDir("hook-message-index-");
+        const dataHome = makeTempDir("hook-message-index-");
+        process.env.XDG_DATA_HOME = dataHome;
+        process.env.MAGIC_CONTEXT_TEST_DATA_DIR = dataHome;
         createOpenCodeDbForHook("ses-index", [
             { id: "u-1", role: "user", text: "index user text" },
             { id: "a-1", role: "assistant", text: "index assistant text" },
@@ -450,7 +461,9 @@ describe("magic-context hook", () => {
     });
 
     it("initializes the dream queue table during setup", () => {
-        process.env.XDG_DATA_HOME = makeTempDir("hook-dream-queue-init-");
+        const dataHome = makeTempDir("hook-dream-queue-init-");
+        process.env.XDG_DATA_HOME = dataHome;
+        process.env.MAGIC_CONTEXT_TEST_DATA_DIR = dataHome;
         requireHook(createMagicContextHook(createMockDeps()));
         const db = openDatabase();
 
@@ -466,6 +479,7 @@ describe("magic-context hook", () => {
     it("disables magic-context and warns when persistent storage is unavailable", () => {
         const dataHome = makeTempDir("hook-storage-disabled-");
         process.env.XDG_DATA_HOME = dataHome;
+        process.env.MAGIC_CONTEXT_TEST_DATA_DIR = dataHome;
         // Block mkdirSync at the cortexkit segment of the new shared path so
         // openDatabase() falls into its in-memory fallback. (Plugin v0.16+
         // moved DB to <XDG_DATA_HOME>/cortexkit/magic-context/.)

--- a/packages/plugin/src/hooks/magic-context/module-state-sync.test.ts
+++ b/packages/plugin/src/hooks/magic-context/module-state-sync.test.ts
@@ -42,12 +42,15 @@ import { closeReadOnlySessionDb } from "./read-session-db";
 const databases: Database[] = [];
 const tempDirs: string[] = [];
 const originalXdgDataHome = process.env.XDG_DATA_HOME;
+const originalTestDataDir = process.env.MAGIC_CONTEXT_TEST_DATA_DIR;
 
 afterEach(() => {
     for (const db of databases.splice(0)) closeQuietly(db);
     closeReadOnlySessionDb();
     if (originalXdgDataHome === undefined) delete process.env.XDG_DATA_HOME;
     else process.env.XDG_DATA_HOME = originalXdgDataHome;
+    if (originalTestDataDir === undefined) delete process.env.MAGIC_CONTEXT_TEST_DATA_DIR;
+    else process.env.MAGIC_CONTEXT_TEST_DATA_DIR = originalTestDataDir;
     for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
     resetCompartmentMirrorCursorsForTest();
 });
@@ -56,6 +59,7 @@ function useTempDataHome(prefix: string): void {
     const dir = mkdtempSync(join(tmpdir(), prefix));
     tempDirs.push(dir);
     process.env.XDG_DATA_HOME = dir;
+    process.env.MAGIC_CONTEXT_TEST_DATA_DIR = dir;
 }
 
 function createOpenCodeDb(

--- a/packages/plugin/src/hooks/magic-context/read-session-chunk.test.ts
+++ b/packages/plugin/src/hooks/magic-context/read-session-chunk.test.ts
@@ -17,9 +17,12 @@ import {
 
 const tempDirs: string[] = [];
 const originalXdgDataHome = process.env.XDG_DATA_HOME;
+const originalTestDataDir = process.env.MAGIC_CONTEXT_TEST_DATA_DIR;
 
 afterEach(() => {
     process.env.XDG_DATA_HOME = originalXdgDataHome;
+    if (originalTestDataDir === undefined) delete process.env.MAGIC_CONTEXT_TEST_DATA_DIR;
+    else process.env.MAGIC_CONTEXT_TEST_DATA_DIR = originalTestDataDir;
     for (const dir of tempDirs) {
         try {
             rmSync(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
@@ -34,6 +37,7 @@ function useTempDataHome(prefix: string): void {
     const dir = mkdtempSync(join(tmpdir(), prefix));
     tempDirs.push(dir);
     process.env.XDG_DATA_HOME = dir;
+    process.env.MAGIC_CONTEXT_TEST_DATA_DIR = dir;
 }
 
 function createOpenCodeDb(sessionId: string): void {

--- a/packages/plugin/src/hooks/magic-context/read-session-db.test.ts
+++ b/packages/plugin/src/hooks/magic-context/read-session-db.test.ts
@@ -14,12 +14,15 @@ import {
 
 const tempDirs: string[] = [];
 const originalXdgDataHome = process.env.XDG_DATA_HOME;
+const originalTestDataDir = process.env.MAGIC_CONTEXT_TEST_DATA_DIR;
 
 afterEach(() => {
     // Close any cached OpenCode read-only DB handle so the new XDG_DATA_HOME
     // points to a fresh DB on the next test case.
     closeReadOnlySessionDb();
     process.env.XDG_DATA_HOME = originalXdgDataHome;
+    if (originalTestDataDir === undefined) delete process.env.MAGIC_CONTEXT_TEST_DATA_DIR;
+    else process.env.MAGIC_CONTEXT_TEST_DATA_DIR = originalTestDataDir;
     for (const dir of tempDirs) {
         try {
             rmSync(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
@@ -365,6 +368,7 @@ function useTempDataHome(prefix: string): void {
     const dir = mkdtempSync(join(tmpdir(), prefix));
     tempDirs.push(dir);
     process.env.XDG_DATA_HOME = dir;
+    process.env.MAGIC_CONTEXT_TEST_DATA_DIR = dir;
 }
 
 interface MessageRow {

--- a/packages/plugin/src/hooks/magic-context/recomp-orchestrator.test.ts
+++ b/packages/plugin/src/hooks/magic-context/recomp-orchestrator.test.ts
@@ -24,16 +24,20 @@ import {
 
 const tempDirs: string[] = [];
 const originalXdg = process.env.XDG_DATA_HOME;
+const originalTestDataDir = process.env.MAGIC_CONTEXT_TEST_DATA_DIR;
 
 function useTempDataHome(prefix: string): void {
     const dir = join(tmpdir(), `${prefix}${Math.random().toString(36).slice(2)}`);
     process.env.XDG_DATA_HOME = dir;
+    process.env.MAGIC_CONTEXT_TEST_DATA_DIR = dir;
     tempDirs.push(dir);
 }
 
 afterEach(() => {
     closeDatabase();
     process.env.XDG_DATA_HOME = originalXdg;
+    if (originalTestDataDir === undefined) delete process.env.MAGIC_CONTEXT_TEST_DATA_DIR;
+    else process.env.MAGIC_CONTEXT_TEST_DATA_DIR = originalTestDataDir;
     for (const dir of tempDirs) rmSync(dir, { recursive: true, force: true });
     tempDirs.length = 0;
 });

--- a/packages/plugin/src/hooks/magic-context/supersession-reclaim.test.ts
+++ b/packages/plugin/src/hooks/magic-context/supersession-reclaim.test.ts
@@ -17,10 +17,13 @@ import { type MessageLike, type TagTarget, tagMessages } from "./tag-messages";
 
 const tempDirs: string[] = [];
 const originalXdgDataHome = process.env.XDG_DATA_HOME;
+const originalTestDataDir = process.env.MAGIC_CONTEXT_TEST_DATA_DIR;
 
 afterEach(() => {
     closeDatabase();
     process.env.XDG_DATA_HOME = originalXdgDataHome;
+    if (originalTestDataDir === undefined) delete process.env.MAGIC_CONTEXT_TEST_DATA_DIR;
+    else process.env.MAGIC_CONTEXT_TEST_DATA_DIR = originalTestDataDir;
     for (const dir of tempDirs) {
         try {
             rmSync(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
@@ -35,6 +38,7 @@ function freshDb(): ReturnType<typeof openDatabase> & object {
     const dir = mkdtempSync(join(tmpdir(), "supersession-"));
     tempDirs.push(dir);
     process.env.XDG_DATA_HOME = dir;
+    process.env.MAGIC_CONTEXT_TEST_DATA_DIR = dir;
     const db = openDatabase();
     if (!db) throw new Error("db open failed");
     return db as ReturnType<typeof openDatabase> & object;

--- a/packages/plugin/src/hooks/magic-context/system-prompt-hash.test.ts
+++ b/packages/plugin/src/hooks/magic-context/system-prompt-hash.test.ts
@@ -58,16 +58,20 @@ import { createSystemPromptHashHandler, isMagicContextInternalAgent } from "./sy
 
 const tempDirs: string[] = [];
 const originalXdgDataHome = process.env.XDG_DATA_HOME;
+const originalTestDataDir = process.env.MAGIC_CONTEXT_TEST_DATA_DIR;
 
 function useTempDataHome(prefix: string): void {
     const dir = mkdtempSync(join(tmpdir(), prefix));
     tempDirs.push(dir);
     process.env.XDG_DATA_HOME = dir;
+    process.env.MAGIC_CONTEXT_TEST_DATA_DIR = dir;
 }
 
 afterEach(() => {
     closeDatabase();
     process.env.XDG_DATA_HOME = originalXdgDataHome;
+    if (originalTestDataDir === undefined) delete process.env.MAGIC_CONTEXT_TEST_DATA_DIR;
+    else process.env.MAGIC_CONTEXT_TEST_DATA_DIR = originalTestDataDir;
     for (const dir of tempDirs) {
         try {
             rmSync(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });

--- a/packages/plugin/src/hooks/magic-context/tag-messages-collision.test.ts
+++ b/packages/plugin/src/hooks/magic-context/tag-messages-collision.test.ts
@@ -27,11 +27,14 @@ import { type MessageLike, tagMessages } from "./transform-operations";
 
 const tempDirs: string[] = [];
 const originalXdgDataHome = process.env.XDG_DATA_HOME;
+const originalTestDataDir = process.env.MAGIC_CONTEXT_TEST_DATA_DIR;
 
 afterEach(() => {
     closeReadOnlySessionDb();
     closeDatabase();
     process.env.XDG_DATA_HOME = originalXdgDataHome;
+    if (originalTestDataDir === undefined) delete process.env.MAGIC_CONTEXT_TEST_DATA_DIR;
+    else process.env.MAGIC_CONTEXT_TEST_DATA_DIR = originalTestDataDir;
     for (const dir of tempDirs) {
         try {
             rmSync(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
@@ -46,6 +49,7 @@ function useTempDataHome(prefix: string): void {
     const dir = mkdtempSync(join(tmpdir(), prefix));
     tempDirs.push(dir);
     process.env.XDG_DATA_HOME = dir;
+    process.env.MAGIC_CONTEXT_TEST_DATA_DIR = dir;
 }
 
 type FallbackLookup =

--- a/packages/plugin/src/hooks/magic-context/tool-input-preservation.test.ts
+++ b/packages/plugin/src/hooks/magic-context/tool-input-preservation.test.ts
@@ -10,10 +10,13 @@ import { type MessageLike, tagMessages } from "./transform-operations";
 
 const tempDirs: string[] = [];
 const originalXdgDataHome = process.env.XDG_DATA_HOME;
+const originalTestDataDir = process.env.MAGIC_CONTEXT_TEST_DATA_DIR;
 
 afterEach(() => {
     closeDatabase();
     process.env.XDG_DATA_HOME = originalXdgDataHome;
+    if (originalTestDataDir === undefined) delete process.env.MAGIC_CONTEXT_TEST_DATA_DIR;
+    else process.env.MAGIC_CONTEXT_TEST_DATA_DIR = originalTestDataDir;
     for (const dir of tempDirs) {
         try {
             rmSync(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
@@ -28,6 +31,7 @@ function useTempDataHome(prefix: string): void {
     const dir = mkdtempSync(join(tmpdir(), prefix));
     tempDirs.push(dir);
     process.env.XDG_DATA_HOME = dir;
+    process.env.MAGIC_CONTEXT_TEST_DATA_DIR = dir;
 }
 
 describe("tool input preservation", () => {

--- a/packages/plugin/src/hooks/magic-context/transform-cache-busting-signals.test.ts
+++ b/packages/plugin/src/hooks/magic-context/transform-cache-busting-signals.test.ts
@@ -67,16 +67,20 @@ type TestMessage = {
 
 const tempDirs: string[] = [];
 const originalXdgDataHome = process.env.XDG_DATA_HOME;
+const originalTestDataDir = process.env.MAGIC_CONTEXT_TEST_DATA_DIR;
 
 function useTempDataHome(prefix: string): void {
     const dir = mkdtempSync(join(tmpdir(), prefix));
     tempDirs.push(dir);
     process.env.XDG_DATA_HOME = dir;
+    process.env.MAGIC_CONTEXT_TEST_DATA_DIR = dir;
 }
 
 afterEach(() => {
     closeDatabase();
     process.env.XDG_DATA_HOME = originalXdgDataHome;
+    if (originalTestDataDir === undefined) delete process.env.MAGIC_CONTEXT_TEST_DATA_DIR;
+    else process.env.MAGIC_CONTEXT_TEST_DATA_DIR = originalTestDataDir;
 
     for (const dir of tempDirs) {
         try {

--- a/packages/plugin/src/hooks/magic-context/transform-compaction-off.test.ts
+++ b/packages/plugin/src/hooks/magic-context/transform-compaction-off.test.ts
@@ -67,6 +67,7 @@ type TestMessage = {
 
 const tempDirs: string[] = [];
 const originalXdgDataHome = process.env.XDG_DATA_HOME;
+const originalTestDataDir = process.env.MAGIC_CONTEXT_TEST_DATA_DIR;
 
 afterEach(() => {
     __resetMessageIndexAsyncForTests();
@@ -75,6 +76,8 @@ afterEach(() => {
     clearModelsDevCache();
     if (originalXdgDataHome === undefined) delete process.env.XDG_DATA_HOME;
     else process.env.XDG_DATA_HOME = originalXdgDataHome;
+    if (originalTestDataDir === undefined) delete process.env.MAGIC_CONTEXT_TEST_DATA_DIR;
+    else process.env.MAGIC_CONTEXT_TEST_DATA_DIR = originalTestDataDir;
     for (const dir of tempDirs) {
         try {
             rmSync(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
@@ -89,6 +92,7 @@ function useTempDataHome(prefix: string): void {
     const dir = mkdtempSync(join(tmpdir(), prefix));
     tempDirs.push(dir);
     process.env.XDG_DATA_HOME = dir;
+    process.env.MAGIC_CONTEXT_TEST_DATA_DIR = dir;
     process.env.XDG_CACHE_HOME = dir;
 }
 

--- a/packages/plugin/src/hooks/magic-context/transform-context-state.test.ts
+++ b/packages/plugin/src/hooks/magic-context/transform-context-state.test.ts
@@ -15,10 +15,13 @@ import { loadContextUsage } from "./transform-context-state";
 
 const tempDirs: string[] = [];
 const originalXdgDataHome = process.env.XDG_DATA_HOME;
+const originalTestDataDir = process.env.MAGIC_CONTEXT_TEST_DATA_DIR;
 
 afterEach(() => {
     closeDatabase();
     process.env.XDG_DATA_HOME = originalXdgDataHome;
+    if (originalTestDataDir === undefined) delete process.env.MAGIC_CONTEXT_TEST_DATA_DIR;
+    else process.env.MAGIC_CONTEXT_TEST_DATA_DIR = originalTestDataDir;
 
     for (const dir of tempDirs) {
         try {
@@ -34,6 +37,7 @@ function useTempDataHome(prefix: string): void {
     const dir = mkdtempSync(join(tmpdir(), prefix));
     tempDirs.push(dir);
     process.env.XDG_DATA_HOME = dir;
+    process.env.MAGIC_CONTEXT_TEST_DATA_DIR = dir;
 }
 
 function createUsageMap() {

--- a/packages/plugin/src/hooks/magic-context/transform-heuristic-cleanup-persistence.test.ts
+++ b/packages/plugin/src/hooks/magic-context/transform-heuristic-cleanup-persistence.test.ts
@@ -25,11 +25,13 @@ type TestMessage = {
 
 const tempDirs: string[] = [];
 const originalXdgDataHome = process.env.XDG_DATA_HOME;
+const originalTestDataDir = process.env.MAGIC_CONTEXT_TEST_DATA_DIR;
 
 function useTempDataHome(prefix: string): void {
     const dir = mkdtempSync(join(tmpdir(), prefix));
     tempDirs.push(dir);
     process.env.XDG_DATA_HOME = dir;
+    process.env.MAGIC_CONTEXT_TEST_DATA_DIR = dir;
 }
 
 function makeTempDir(prefix: string): string {
@@ -119,6 +121,8 @@ function stripTagPrefix(value: string): string {
 afterEach(() => {
     closeDatabase();
     process.env.XDG_DATA_HOME = originalXdgDataHome;
+    if (originalTestDataDir === undefined) delete process.env.MAGIC_CONTEXT_TEST_DATA_DIR;
+    else process.env.MAGIC_CONTEXT_TEST_DATA_DIR = originalTestDataDir;
 
     for (const dir of tempDirs) {
         try {

--- a/packages/plugin/src/hooks/magic-context/transform-index-staleness.test.ts
+++ b/packages/plugin/src/hooks/magic-context/transform-index-staleness.test.ts
@@ -34,9 +34,12 @@ type TestMessage = {
 
 const tempDirs: string[] = [];
 const originalXdgDataHome = process.env.XDG_DATA_HOME;
+const originalTestDataDir = process.env.MAGIC_CONTEXT_TEST_DATA_DIR;
 afterEach(() => {
     closeDatabase();
     process.env.XDG_DATA_HOME = originalXdgDataHome;
+    if (originalTestDataDir === undefined) delete process.env.MAGIC_CONTEXT_TEST_DATA_DIR;
+    else process.env.MAGIC_CONTEXT_TEST_DATA_DIR = originalTestDataDir;
     for (const dir of tempDirs) {
         try {
             rmSync(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
@@ -51,6 +54,7 @@ function useTempDataHome(prefix: string): void {
     const dir = mkdtempSync(join(tmpdir(), prefix));
     tempDirs.push(dir);
     process.env.XDG_DATA_HOME = dir;
+    process.env.MAGIC_CONTEXT_TEST_DATA_DIR = dir;
 }
 function createTestTransform(sessionId: string) {
     const shouldExecute = mock<Scheduler["shouldExecute"]>(() => "defer");

--- a/packages/plugin/src/hooks/magic-context/transform-operations.test.ts
+++ b/packages/plugin/src/hooks/magic-context/transform-operations.test.ts
@@ -28,10 +28,13 @@ type TestMessage = {
 
 const tempDirs: string[] = [];
 const originalXdgDataHome = process.env.XDG_DATA_HOME;
+const originalTestDataDir = process.env.MAGIC_CONTEXT_TEST_DATA_DIR;
 
 afterEach(() => {
     closeDatabase();
     process.env.XDG_DATA_HOME = originalXdgDataHome;
+    if (originalTestDataDir === undefined) delete process.env.MAGIC_CONTEXT_TEST_DATA_DIR;
+    else process.env.MAGIC_CONTEXT_TEST_DATA_DIR = originalTestDataDir;
     for (const dir of tempDirs) {
         try {
             rmSync(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
@@ -46,6 +49,7 @@ function useTempDataHome(prefix: string): void {
     const dir = mkdtempSync(join(tmpdir(), prefix));
     tempDirs.push(dir);
     process.env.XDG_DATA_HOME = dir;
+    process.env.MAGIC_CONTEXT_TEST_DATA_DIR = dir;
 }
 
 describe("tagMessages", () => {

--- a/packages/plugin/src/hooks/magic-context/transform-todo-state.test.ts
+++ b/packages/plugin/src/hooks/magic-context/transform-todo-state.test.ts
@@ -36,11 +36,13 @@ import type { MessageLike } from "./transform-operations";
 import { applyTodoSynthesis } from "./transform-postprocess-phase";
 
 const tempDirs: string[] = [];
+const originalTestDataDir = process.env.MAGIC_CONTEXT_TEST_DATA_DIR;
 
 function useTempDataHome(prefix: string): void {
     const dir = mkdtempSync(join(tmpdir(), prefix));
     tempDirs.push(dir);
     process.env.XDG_DATA_HOME = dir;
+    process.env.MAGIC_CONTEXT_TEST_DATA_DIR = dir;
 }
 
 afterEach(() => {
@@ -53,6 +55,8 @@ afterEach(() => {
         }
     tempDirs.length = 0;
     process.env.XDG_DATA_HOME = undefined;
+    if (originalTestDataDir === undefined) delete process.env.MAGIC_CONTEXT_TEST_DATA_DIR;
+    else process.env.MAGIC_CONTEXT_TEST_DATA_DIR = originalTestDataDir;
 });
 
 const ACTIVE_TODOS_JSON = JSON.stringify([

--- a/packages/plugin/src/hooks/magic-context/transform.test.ts
+++ b/packages/plugin/src/hooks/magic-context/transform.test.ts
@@ -90,6 +90,7 @@ type TestMessage = {
 const tempDirs: string[] = [];
 const originalXdgDataHome = process.env.XDG_DATA_HOME;
 const originalXdgCacheHome = process.env.XDG_CACHE_HOME;
+const originalTestDataDir = process.env.MAGIC_CONTEXT_TEST_DATA_DIR;
 
 afterEach(() => {
     __resetMessageIndexAsyncForTests();
@@ -101,6 +102,8 @@ afterEach(() => {
     else process.env.XDG_DATA_HOME = originalXdgDataHome;
     if (originalXdgCacheHome === undefined) delete process.env.XDG_CACHE_HOME;
     else process.env.XDG_CACHE_HOME = originalXdgCacheHome;
+    if (originalTestDataDir === undefined) delete process.env.MAGIC_CONTEXT_TEST_DATA_DIR;
+    else process.env.MAGIC_CONTEXT_TEST_DATA_DIR = originalTestDataDir;
 
     for (const dir of tempDirs) {
         try {
@@ -128,6 +131,7 @@ function useTempDataHome(prefix: string): void {
     const dir = makeTempDir(prefix);
     process.env.XDG_DATA_HOME = dir;
     process.env.XDG_CACHE_HOME = dir;
+    process.env.MAGIC_CONTEXT_TEST_DATA_DIR = dir;
 }
 
 function text(message: TestMessage, index: number): string {

--- a/packages/plugin/src/hooks/magic-context/upgrade-reminder.test.ts
+++ b/packages/plugin/src/hooks/magic-context/upgrade-reminder.test.ts
@@ -16,12 +16,15 @@ import {
 } from "./upgrade-reminder";
 
 let prevDataHome: string | undefined;
+let prevTestDataDir: string | undefined;
 let tempHome: string;
 
 beforeEach(() => {
     prevDataHome = process.env.XDG_DATA_HOME;
+    prevTestDataDir = process.env.MAGIC_CONTEXT_TEST_DATA_DIR;
     tempHome = mkdtempSync(join(tmpdir(), "mc-upgrade-rem-"));
     process.env.XDG_DATA_HOME = tempHome;
+    process.env.MAGIC_CONTEXT_TEST_DATA_DIR = tempHome;
     mkdirSync(join(tempHome, "cortexkit", "magic-context"), { recursive: true });
     closeDatabase();
     __resetUpgradeReminderProcessGuard();
@@ -31,6 +34,8 @@ afterEach(() => {
     closeDatabase();
     if (prevDataHome === undefined) delete process.env.XDG_DATA_HOME;
     else process.env.XDG_DATA_HOME = prevDataHome;
+    if (prevTestDataDir === undefined) delete process.env.MAGIC_CONTEXT_TEST_DATA_DIR;
+    else process.env.MAGIC_CONTEXT_TEST_DATA_DIR = prevTestDataDir;
     rmSync(tempHome, { recursive: true, force: true });
 });
 

--- a/packages/plugin/src/shared/announcement.test.ts
+++ b/packages/plugin/src/shared/announcement.test.ts
@@ -21,11 +21,14 @@ import * as path from "node:path";
 
 let tmpRoot = "";
 let originalXdg: string | undefined;
+let originalTestDataDir: string | undefined;
 
 beforeEach(() => {
     tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "mc-announcement-test-"));
     originalXdg = process.env.XDG_DATA_HOME;
+    originalTestDataDir = process.env.MAGIC_CONTEXT_TEST_DATA_DIR;
     process.env.XDG_DATA_HOME = tmpRoot;
+    process.env.MAGIC_CONTEXT_TEST_DATA_DIR = tmpRoot;
 });
 
 afterEach(() => {
@@ -34,6 +37,8 @@ afterEach(() => {
     } else {
         process.env.XDG_DATA_HOME = originalXdg;
     }
+    if (originalTestDataDir === undefined) delete process.env.MAGIC_CONTEXT_TEST_DATA_DIR;
+    else process.env.MAGIC_CONTEXT_TEST_DATA_DIR = originalTestDataDir;
     try {
         // maxRetries/retryDelay ride out transient EBUSY/EPERM on Windows.
         fs.rmSync(tmpRoot, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });

--- a/packages/plugin/src/shared/models-dev-cache.test.ts
+++ b/packages/plugin/src/shared/models-dev-cache.test.ts
@@ -123,6 +123,7 @@ describe("output-token reservation", () => {
 describe("models-dev-cache (SDK-only)", () => {
     let tempDir: string;
     let originalXdgData: string | undefined;
+    let originalTestDataDir: string | undefined;
 
     function makeClient(providers: Array<unknown>) {
         return { config: { providers: async () => ({ data: { providers } }) } };
@@ -133,7 +134,9 @@ describe("models-dev-cache (SDK-only)", () => {
         // Isolate the persisted-cache file under a temp data dir so tests never
         // touch the real ~/.local/share/cortexkit/magic-context cache.
         originalXdgData = process.env.XDG_DATA_HOME;
+        originalTestDataDir = process.env.MAGIC_CONTEXT_TEST_DATA_DIR;
         process.env.XDG_DATA_HOME = tempDir;
+        process.env.MAGIC_CONTEXT_TEST_DATA_DIR = tempDir;
         setOutputReserveConfig(undefined);
         clearModelsDevCache();
     });
@@ -141,6 +144,8 @@ describe("models-dev-cache (SDK-only)", () => {
     afterEach(() => {
         if (originalXdgData === undefined) delete process.env.XDG_DATA_HOME;
         else process.env.XDG_DATA_HOME = originalXdgData;
+        if (originalTestDataDir === undefined) delete process.env.MAGIC_CONTEXT_TEST_DATA_DIR;
+        else process.env.MAGIC_CONTEXT_TEST_DATA_DIR = originalTestDataDir;
         try {
             rmSync(tempDir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
         } catch {

--- a/packages/plugin/src/tui/data/notification-socket.test.ts
+++ b/packages/plugin/src/tui/data/notification-socket.test.ts
@@ -18,6 +18,7 @@ import {
 } from "./notification-socket";
 
 const originalXdgDataHome = process.env.XDG_DATA_HOME;
+const originalTestDataDir = process.env.MAGIC_CONTEXT_TEST_DATA_DIR;
 const tempDirs: string[] = [];
 const servers: MagicContextRpcServer[] = [];
 const legacyServers: Array<ReturnType<typeof Bun.serve>> = [];
@@ -38,12 +39,15 @@ afterEach(() => {
     } else {
         process.env.XDG_DATA_HOME = originalXdgDataHome;
     }
+    if (originalTestDataDir === undefined) delete process.env.MAGIC_CONTEXT_TEST_DATA_DIR;
+    else process.env.MAGIC_CONTEXT_TEST_DATA_DIR = originalTestDataDir;
 });
 
 function makeDataHome(): string {
     const dir = mkdtempSync(join(tmpdir(), "mc-notification-socket-"));
     tempDirs.push(dir);
     process.env.XDG_DATA_HOME = dir;
+    process.env.MAGIC_CONTEXT_TEST_DATA_DIR = dir;
     return dir;
 }
 


### PR DESCRIPTION
## What's broken

`#372` reordered `getMagicContextStorageResolution()` so `MAGIC_CONTEXT_TEST_DATA_DIR` is checked before `XDG_DATA_HOME`:

```
1. MAGIC_CONTEXT_TEST_DATA_DIR   ← process-wide, set once by test-preload.ts:33
2. NODE_ENV === "test"           → memoized process-wide backstop
3. MAGIC_CONTEXT_STORAGE_DIR
4. XDG_DATA_HOME                 ← per-test isolation used to be honored here
5. platform default
```

Test files isolate themselves by setting `process.env.XDG_DATA_HOME` to a fresh `mkdtempSync` dir (usually via a locally-defined `useTempDataHome` helper). Since `test-preload.ts` sets `MAGIC_CONTEXT_TEST_DATA_DIR` once for the whole process, branch 1 now always wins — every per-test override is inert and all tests in a process share **one** database.

`test-preload.ts:18` states the contract that broke:

> Tests that set their own XDG_DATA_HOME still work (they override per-test).

Fixtures that reuse stable ids (`ses-1`, `msg-boundary`) then collide on the second insert:

```
UNIQUE constraint failed: session_meta.session_id
UNIQUE constraint failed: compartments.session_id, compartments.sequence
UNIQUE constraint failed: tags.session_id, tags.tag_number
UNIQUE constraint failed: memories.project_path, memories.category, memories.normalized_hash
no such table: marker / source_marker
```

## Reproduction on current master

```
$ git checkout master && git rev-parse --short HEAD
58535241

$ cd packages/plugin && bun test src/hooks/magic-context/compaction-marker-manager.test.ts
 4 pass
 9 fail

$ bun test          # full plugin suite
 4007 pass
 140 fail
```

## Why the fix is in the helpers, not the resolver

I tried the resolver first — honor `XDG_DATA_HOME` when it differs from the test data dir. That fixes the repro (13/0) but breaks `data-path.test.ts:155`:

```ts
test("test storage isolation takes precedence over XDG_DATA_HOME", () => {
    process.env.MAGIC_CONTEXT_TEST_DATA_DIR = "/tmp/mc-test-isolation";
    process.env.XDG_DATA_HOME = "/tmp/custom-data";
    expect(getMagicContextStorageDir()).toBe(".../mc-test-isolation/...");
});
```

That test deliberately sets the two variables to *different* values and requires the test-data-dir to win — the exact value pattern per-test isolation needs to resolve the other way. The resolver cannot satisfy both, so the resolver is the wrong layer and the v26 escape guard stays exactly as `#372` left it.

Instead, isolation sites now set the authoritative variable alongside `XDG_DATA_HOME`:

```ts
const originalTestDataDir = process.env.MAGIC_CONTEXT_TEST_DATA_DIR;

function useTempDataHome(prefix: string): string {
    const dir = mkdtempSync(join(tmpdir(), prefix));
    process.env.XDG_DATA_HOME = dir;
    process.env.MAGIC_CONTEXT_TEST_DATA_DIR = dir;   // ← added
    ...
}

afterEach(() => {
    process.env.XDG_DATA_HOME = originalXdgDataHome;
    if (originalTestDataDir === undefined) delete process.env.MAGIC_CONTEXT_TEST_DATA_DIR;
    else process.env.MAGIC_CONTEXT_TEST_DATA_DIR = originalTestDataDir;
    ...
});
```

Restore is undefined-safe (`delete` rather than assigning the string `"undefined"`).

## Scope

43 test files. Selected **behaviorally** — any test setting `XDG_DATA_HOME` to obtain a private store — not by helper name: 36 with a `useTempDataHome` helper, plus 7 named/inline sites (`hook`, `supersession-reclaim`, `upgrade-reminder`, `notification-socket`, `window-report-ledger`, `models-dev-cache`, `announcement`).

**Deliberately untouched:**

- `data-path.ts` — the resolver is correct as written
- `test-preload.ts`, `bunfig.toml` — the process-wide default is the v26 safety guard
- Tests that manipulate or delete `XDG_DATA_HOME` to exercise path resolution *itself* (`data-path.test.ts` and similar). Changing those would make them assert the wrong thing; `data-path.test.ts` stays 30/0.

No production code changed — the diff is test files only.

## Result

```
              master          this PR
plugin suite  4007 / 140      4138 / 9
tsc           0               0
lint          3 errors        3 errors   (identical to master: import order in
                                          storage-db + execute-status)
```

Totals reconcile at 4147 both runs — no tests lost or added.

The 9 remaining failures each reproduce **in isolation on clean master** and are unrelated to storage isolation, so they're left for separate fixes:

- `storage-db-migration` legacy-copy/path tests (6) — `0 pass / 6 fail` on master standalone
- `scripts/export-window-reports` — empty reports
- `features/window-report-ledger` — swallowed-write diagnostic
- `hooks/inject-compartments` — one m[0]/m[1] timeout

Happy to split those out into their own issues if useful.

---

Found while rebasing a downstream fork onto master; the failures are upstream's, not the fork's — verified on a branch with zero diff from `58535241`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/magic-context/pr/374"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790522419&installation_model_id=22398&pr_number=374&repository=cortexkit%2Fmagic-context&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Fmagic-context%2Fpull%2F374&signature=6ef6c591a1b20ea262d81c80d4e34c9b5b36d8e96be6b20edd6f7ca9c700d2a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores per-test DB isolation that broke after `MAGIC_CONTEXT_TEST_DATA_DIR` gained precedence over `XDG_DATA_HOME` in storage resolution. Tests that set `XDG_DATA_HOME` for isolation now also set `MAGIC_CONTEXT_TEST_DATA_DIR` to the same temp dir, so each test gets its own database instead of sharing one process-wide DB (which previously caused unique-constraint failures on reused fixture ids).

- Updated isolation helpers in 43 test files with undefined-safe restore of both env vars; no production code changed.
- Left the resolver and path-resolution tests untouched, since `data-path.test.ts` requires the test-data-dir to win over a differing `XDG_DATA_HOME`.

<sup>Written for commit 75a56323d0d689d493ef7926bcb7812818a995eb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/magic-context/pull/374?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR restores per-test database isolation after `MAGIC_CONTEXT_TEST_DATA_DIR` gained precedence over `XDG_DATA_HOME`.
- Synchronizes the authoritative test-data directory with each test’s temporary data home.
- Restores the original environment value during cleanup without converting an absent value to `"undefined"`.
- Applies the isolation pattern across 43 storage-dependent plugin test files.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the changed tests consistently preserving isolated storage and restoring process state.

The changes are confined to test setup and cleanup, use equivalent path semantics for both environment variables, close cached database handles before cleanup, and do not introduce a concrete failure.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/plugin/src/features/magic-context/storage-db.test.ts | Keeps database-path tests isolated by synchronizing and restoring the authoritative test storage variable. |
| packages/plugin/src/hooks/magic-context/hook.test.ts | Updates several inline temporary-storage setups and shared cleanup without changing tested production behavior. |
| packages/plugin/src/shared/models-dev-cache.test.ts | Directs models.dev cache tests to the same per-test temporary root used by XDG isolation. |
| packages/plugin/src/tui/data/notification-socket.test.ts | Aligns notification-socket test storage with its temporary data home and restores the preload value afterward. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(test): restore per-test DB isolation..."](https://github.com/cortexkit/magic-context/commit/75a56323d0d689d493ef7926bcb7812818a995eb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57939336)</sub>

**Context used:**

- Knowledge Base — [Protect Shared Storage Tests from Production Database Access](https://app.greptile.com/cortexkit/-/custom-context/knowledge-base/cortexkit/magic-context/-/reverts/incident-mitigation_296-20260810-shared-storage-test-escape-6a3cb2c.md)

<!-- /greptile_comment -->