### PR TITLE
fix(rust): thread subc.connection_file to the transform transport

### DIFF
--- a/packages/plugin/src/hooks/magic-context/hook.ts
+++ b/packages/plugin/src/hooks/magic-context/hook.ts
@@ -178,6 +178,10 @@ export interface MagicContextDeps {
             min_chars: number;
         };
         transform_mode?: ResolvedTransformMode;
+        /** Path to the subc daemon's connection file. Threaded to the module
+         *  transport so a host that publishes it outside the default data-dir
+         *  location (e.g. a systemd RuntimeDirectory) is actually reachable. */
+        subc?: { connection_file: string };
         /** Compaction-off mode gate (issue #266). Resolved ONCE here at the
          *  session-hook construction boundary via isCompactionEnabled; the
          *  resolved boolean is threaded to the transform phases. */
@@ -774,7 +778,7 @@ export function createMagicContextHook(deps: MagicContextDeps) {
     const authorityRecoveryModuleClient =
         deps.rustModeModuleClient ??
         (() => {
-            const transport = new SubcModuleTransport();
+            const transport = new SubcModuleTransport(deps.config.subc?.connection_file);
             const client: RustModeModuleClient = {
                 call: (args) => transport.call(args),
                 stateSyncCapabilities: (args) => transport.stateSyncCapabilities(args),

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -203,7 +203,9 @@ const server: Plugin = async (ctx) => {
 
     const liveSessionState = createLiveSessionState();
     const rustModeModuleClient: RustModeModuleClient | undefined =
-        pluginConfig.transform_mode === "rust" ? new SubcModuleTransport() : undefined;
+        pluginConfig.transform_mode === "rust"
+            ? new SubcModuleTransport(pluginConfig.subc?.connection_file)
+            : undefined;
 
     const hooks = await createSessionHooksAsync({
         ctx,


### PR DESCRIPTION
Fixes #375.

## The bug

`SubcModuleTransport` accepts a connection-file path, but both transform-lane construction sites call it with no argument:

```
packages/plugin/src/index.ts:208                  new SubcModuleTransport()
packages/plugin/src/hooks/magic-context/hook.ts:796  new SubcModuleTransport()
```

so `connectionFile ?? getDefaultConnectionFile()` always resolves to the default. Meanwhile `subc.connection_file` **is** parsed and validated — and is read exactly once, purely as a boolean gate (`config/index.ts:470-476`):

```ts
const connectionFile = (subc as Record<string, unknown>).connection_file;
return typeof connectionFile === "string" && connectionFile.trim().length > 0;
```

`resolveTransformMode` requires that to be true before returning `"rust"`. Net effect: **setting the key unlocks rust mode, then the path you set is discarded.**

The embedding lane already threads the same key correctly (`plugin/embedding-routing.ts:87`), so on one host a single config value could send Synapse embeddings to the configured socket while the transform lane looked somewhere else entirely.

## Observed failure

Daemon 0.10.0 publishing to `/run/user/1000/subc-connection.json`; module registered, healthy, restarts 0/3.

```jsonc
{ "transform_mode": "rust", "subc": { "connection_file": "/run/user/1000/subc-connection.json" } }
```

```
ENOENT: no such file or directory, statx '<data-dir>/cortexkit/run/subc-connection.json'
rust transform failed; attempting LKG replay: ENOENT …
lkg_miss
rust pass: decision=error reason=none served_from=raw applied=false module=0.0 ms
```

```
MISSING  ~/.local/share/cortexkit/run/subc-connection.json   ← what it used
EXISTS   /run/user/1000/subc-connection.json                 ← what was configured
```

Over ~40 passes: `defer 36 · error 4 · parked 2 · execute 1`, with `materialized = 0` on every row. Zero materializations means m[0]/m[1] are never built, so the sidebar renders empty and the session shows "reconnecting".

Worth noting for triage: `module=0.0 ms` and the daemon's own `health ok / in_flight=0 / consecutive_error_count 0` are both *correct*. Nothing ever crosses the wire, so both endpoints look healthy and the failure is invisible from the module side.

## The change

Thread the configured value at both sites, defaulting exactly as before when the key is absent:

```ts
// index.ts
pluginConfig.transform_mode === "rust"
    ? new SubcModuleTransport(pluginConfig.subc?.connection_file)
    : undefined;

// hook.ts (TS recovery arm)
const transport = new SubcModuleTransport(deps.config.subc?.connection_file);
```

plus `subc?: { connection_file: string }` on the session-hook deps config type so the second site can reach it.

2 files, +8/−2. No behaviour change when `subc.connection_file` is unset.

## Verification

```
                        this PR      clean master
plugin suite            4163 / 1     4163 / 1      ← identical
module-transport tests  23 / 0
tsc                     0
lint                    6 errors     6 errors      ← identical, all in files I didn't touch
```

The 1 test failure and 6 lint errors reproduce on clean `master` (`classify.ts`, `execute-status.ts`, `storage-db.test.ts`, `rust-mode-transform.test.ts` — none in this diff).

Verified end-to-end on a live daemon: with the fix, the transport targets the configured path instead of the default.

## On test coverage — stated plainly

I have **not** added a unit test, and I'd rather say so than bury it. The existing `module-transport.test.ts` covers the *constructor*, which was already correct — the defect is the two call sites, which construct lazily inside a plugin-factory and a closure, and nothing currently exercises that wiring. The obvious harness would need `mock.module`, which is process-global in Bun and has caused cross-file bleed in this repo before (#279).

So the evidence here is the live reproduction above rather than a regression test. If you'd like the wiring locked down, I'm happy to add a harness in whatever shape you prefer — I didn't want to invent one unprompted in a fix this small.

## Two adjacent observations (not changed here)

1. `hasUserTierSubcConfig` validates that a usable path exists, while the transport then uses a *different* path — so the activation gate doesn't gate on the thing it validates. This PR closes that for free.
2. The ENOENT recurs per-pass, each time re-entering backoff. A startup-time existence check (`configured subc.connection_file not found at <path>`) would turn a repeating soft failure into one actionable line. Happy to add separately if wanted.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/magic-context/pr/376"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790529640&installation_model_id=22398&pr_number=376&repository=cortexkit%2Fmagic-context&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Fmagic-context%2Fpull%2F376&signature=e813c01db830ac1c7b5f99b47f15dce882266b92e60cd9535788bbf91b15134e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes rust transform mode so the configured `subc.connection_file` is passed to the module transport instead of always falling back to the default path; the embedding lane already used this key, so the two lanes could point at different sockets.

**Bug Fixes**
- Threads the connection file through both transform transport construction sites.
- Adds `subc?: { connection_file: string }` to the session-hook deps config type.
- Behavior is unchanged when the key is absent.

<sup>Written for commit 50c74241ecb23cf31b9289f1f1aec3f1baf58ff0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/magic-context/pull/376?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR threads the resolved `subc.connection_file` setting into both Rust transform transport construction paths, preserving the existing default when unset.
- Uses the configured daemon discovery file for the primary plugin transport.
- Adds the same configuration field to session-hook dependencies and applies it to the recovery transport.
- Leaves the separate wake-plane capability probe on the default discovery path.
</details>


<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with a non-blocking inconsistency where wake-plane capability discovery still ignores a configured non-default connection file.

Both changed transform transports correctly use the configured daemon path, but the sibling wake-plane probe remains tied to the default location and therefore continues local smart-note evaluation for non-default daemon deployments.

**Files Needing Attention:** packages/plugin/src/index.ts

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/plugin/src/index.ts | Correctly passes the configured connection-file path to the primary Rust transport, but exposes divergence with the default-only wake-plane probe. |
| packages/plugin/src/hooks/magic-context/hook.ts | Preserves the resolved subc configuration in the hook dependency shape and passes it to the fallback recovery transport. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  C[subc.connection_file] --> T[Transform transport]
  C --> R[Recovery transport]
  T --> D[Configured subc daemon]
  R --> D
  W[Wake-plane probe] --> P[Default connection file]
  P --> U[Unknown when only configured file exists]
  U --> L[Local smart-note evaluation]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(rust): thread subc.connection\_file t..."](https://github.com/cortexkit/magic-context/commit/50c74241ecb23cf31b9289f1f1aec3f1baf58ff0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57986274)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [OpenCode plugin runtime](https://app.greptile.com/cortexkit/-/custom-context/knowledge-base/cortexkit/magic-context/-/docs/opencode-plugin.md)
- Knowledge Base — [Configuration and harness compatibility](https://app.greptile.com/cortexkit/-/custom-context/knowledge-base/cortexkit/magic-context/-/docs/configuration-and-compatibility.md)

<!-- /greptile_comment -->