### PR TITLE
fix(rust): drop supersede pointers outside the authority seed set

### DIFF
--- a/packages/plugin/src/hooks/magic-context/rust-mode-transform.test.ts
+++ b/packages/plugin/src/hooks/magic-context/rust-mode-transform.test.ts
@@ -4220,3 +4220,98 @@ describe("raw fallback refusal copy and early abort", () => {
         expect(parkedMessages).toEqual([ENGINE_RECONNECTING_USER_MESSAGE]);
     });
 });
+
+describe("authoritySeedRows — supersede pointer resolution (issue #377)", () => {
+    // The store records a pending memory reference for any seeded row whose
+    // superseded_by_memory_id it cannot resolve, and authority_finish_prepare
+    // rejects the memories-domain handoff while any pending references exist.
+    // A target outside the seed set can never resolve, so the pending survives
+    // the resolution sweep and blocks rust mode permanently.
+    function seedDb(): ContextDatabase {
+        const db = new Database(":memory:") as ContextDatabase;
+        initializeDatabase(db);
+        return db;
+    }
+
+    function insert(
+        db: ContextDatabase,
+        project: string,
+        content: string,
+        status: string,
+    ): number {
+        const now = Date.now();
+        db.prepare(
+            `INSERT INTO memories
+               (project_path, category, content, normalized_hash, source_type,
+                seen_count, retrieval_count, first_seen_at, created_at, updated_at,
+                last_seen_at, status)
+             VALUES (?, 'ARCHITECTURE', ?, ?, 'agent', 1, 0, ?, ?, ?, ?, ?)`,
+        ).run(project, content, `hash-${content}`, now, now, now, now, status);
+        return Number(
+            (db.prepare("SELECT last_insert_rowid() AS id").get() as { id: number }).id,
+        );
+    }
+
+    it("drops a supersede pointer whose target is absent from the seed set", () => {
+        const db = seedDb();
+        try {
+            const project = "git:seed-test";
+            const survivor = insert(db, project, "survivor", "active");
+            const superseded = insert(db, project, "superseded", "archived");
+            const orphaned = insert(db, project, "orphaned", "archived");
+
+            // Resolvable: target is in the same seed set.
+            db.prepare("UPDATE memories SET superseded_by_memory_id = ? WHERE id = ?").run(
+                survivor,
+                superseded,
+            );
+            // Unresolvable: target id never existed in this project.
+            db.prepare("UPDATE memories SET superseded_by_memory_id = ? WHERE id = ?").run(
+                999_999,
+                orphaned,
+            );
+
+            const rows = __rustModeTransformTest.authoritySeedRows(db, project, "memories");
+            const byId = new Map(
+                rows.map((row) => [
+                    Number((row as { source_row_id: unknown }).source_row_id),
+                    (row as { snapshot: Record<string, unknown> }).snapshot,
+                ]),
+            );
+
+            // The dead link is dropped so the module never records a pending reference.
+            expect(byId.get(orphaned)?.superseded_by_memory_id).toBeNull();
+            // The resolvable pointer is preserved verbatim — this must stay surgical,
+            // not a blanket null of the column.
+            expect(byId.get(superseded)?.superseded_by_memory_id).toBe(survivor);
+        } finally {
+            closeQuietly(db);
+        }
+    });
+
+    it("drops a supersede pointer whose target belongs to another project", () => {
+        const db = seedDb();
+        try {
+            const project = "git:seed-a";
+            const foreign = insert(db, "git:seed-b", "foreign-target", "active");
+            const local = insert(db, project, "local", "archived");
+            db.prepare("UPDATE memories SET superseded_by_memory_id = ? WHERE id = ?").run(
+                foreign,
+                local,
+            );
+
+            const rows = __rustModeTransformTest.authoritySeedRows(db, project, "memories");
+            const snapshot = (
+                rows.find(
+                    (row) => Number((row as { source_row_id: unknown }).source_row_id) === local,
+                ) as { snapshot: Record<string, unknown> }
+            ).snapshot;
+
+            // The seed set is project-scoped, so a cross-project target is
+            // equally unresolvable module-side.
+            expect(snapshot.superseded_by_memory_id).toBeNull();
+        } finally {
+            closeQuietly(db);
+        }
+    });
+});

--- a/packages/plugin/src/hooks/magic-context/rust-mode-transform.ts
+++ b/packages/plugin/src/hooks/magic-context/rust-mode-transform.ts
@@ -927,6 +927,15 @@ function authoritySeedRows(
                   )
                   .all(projectPath, projectPath);
     const memoryRows = snapshots.filter(isRecord);
+    // A `superseded_by_memory_id` pointing outside this seed set can never resolve
+    // module-side: the store records it as a pending memory reference, and the
+    // resolution sweep only clears pendings whose target later appears in
+    // mc_memories. A target that is absent here is absent for good (its row was
+    // hard-deleted after an archive), so the pending would survive to
+    // authority_finish_prepare and permanently reject the memories-domain handoff.
+    // Dropping the dead link here keeps the gate meaningful for the case it exists
+    // to catch: a target the host DID send that the module failed to ingest.
+    const seededIds = new Set(memoryRows.map((row) => Number(row.id)));
     const mappings =
         domain === "memories"
             ? getMemoryVerifications(
@@ -937,16 +946,22 @@ function authoritySeedRows(
     return memoryRows.map((snapshot) => {
         const id = Number(snapshot.id);
         const mapping = mappings.get(id);
+        const resolvedSnapshot =
+            domain === "memories" &&
+            snapshot.superseded_by_memory_id != null &&
+            !seededIds.has(Number(snapshot.superseded_by_memory_id))
+                ? { ...snapshot, superseded_by_memory_id: null }
+                : snapshot;
         const seededSnapshot =
             domain === "memories" && mapping
                 ? {
-                      ...snapshot,
+                      ...resolvedSnapshot,
                       mapping: mapping.hasSentinel ? null : mapping.files,
                       mapping_origin: mapping.mappingOrigin,
                   }
                 : domain === "notes" && snapshot.project_path == null
-                  ? { ...snapshot, project_path: projectPath }
-                  : snapshot;
+                  ? { ...resolvedSnapshot, project_path: projectPath }
+                  : resolvedSnapshot;
         return { source_row_id: snapshot.id, snapshot: seededSnapshot };
     });
 }
@@ -3006,6 +3021,7 @@ export async function runRustModeTransform(
 
 export const __rustModeTransformTest = {
     applyNativeMessagesVerbatim,
+    authoritySeedRows,
     contentSnapshotsFor,
     snapshotTags: {
         array: LKG_SNAPSHOT_ARRAY,


### PR DESCRIPTION
Fixes #377.

## The bug

`authoritySeedRows` (`rust-mode-transform.ts:907`) seeds every memory for a project — no status filter — and forwards `superseded_by_memory_id` verbatim:

```ts
db.prepare("SELECT * FROM memories WHERE project_path = ? ORDER BY id ASC").all(projectPath)
```

When that target is absent from the seed set, `seed_memory_snapshots` records a pending memory reference (`crates/mc-store/src/lib.rs:14948-14958`). The resolution sweep at `:15068-15080` only clears pendings whose target later appears in `mc_memories`, so a hard-deleted target never clears. The pending survives to `authority_finish_prepare` (`:14035-14047`), which rejects the handoff:

```
store: storage backend: authority prepare complete rejected: 2 unresolved pending memory references
→ lkg_miss → decision=error → served_from=raw → applied=false
mc_rust_park_transition failure_passes=3 pass_count=3 park_count=1
```

Every pass degrades with `materialized = 0`, so m[0]/m[1] are never built — empty sidebar, "reconnecting" notification, and rust mode is unreachable. It is permanent: nothing repairs supersede pointers and the targets are gone.

The pointers come from ordinary merge/curate activity — the losing row records `superseded_by_memory_id`, the winner is later archived then deleted, the pointer outlives it. Nothing in the TS path dereferences it, so it stays inert and invisible until the module's store resolves it.

## Why host-side and not a gate relaxation

My first instinct (and the original text of #377) was to relax the Rust gate — treat unresolvable as resolved-to-null in `seed_memory_snapshots`. After finding the resolution sweep, I think that's wrong: it would also swallow a **genuine ingest failure**, where the host sent the target and the module failed to store it. The store cannot tell those apart.

The host can, because it knows the seed set it just sent:

- target absent from the seed set → dead link, can never resolve → drop it here
- target present in the seed set but missing module-side → real failure → pending fires, gate correctly rejects

So the gate keeps its protective value and only the provably-dead links are dropped.

## The change

```ts
const seededIds = new Set(memoryRows.map((row) => Number(row.id)));
...
const resolvedSnapshot =
    domain === "memories" &&
    snapshot.superseded_by_memory_id != null &&
    !seededIds.has(Number(snapshot.superseded_by_memory_id))
        ? { ...snapshot, superseded_by_memory_id: null }
        : snapshot;
```

Note the seed set is **project-scoped**, so a target belonging to another project is equally unresolvable — covered by the same check and by a test.

## Verification

Red-checked (reverted the fix, confirmed both new tests fail for the right reason, restored):

```
fix reverted   82 pass / 2 fail
fix restored   84 pass / 0 fail
```

Gates:

```
                    this PR      clean master
plugin suite        4165 / 1     4163 / 1      (+2 = the new tests; same 1 pre-existing failure)
tsc                 0
lint                6 errors     6 errors      identical, none in touched files
```

Simulated against a real 3,101-memory store, on the project that hit this:

```
BEFORE   unresolvable pointers sent: 2     id=25 → 265 (archived)
                                           id=26 → 265 (archived)
AFTER    unresolvable pointers sent: 0
         resolvable pointers preserved: 61 of 63
```

61-of-63 is the number that matters — the change is surgical, not a blanket null of the column.

## Scope in the wild

Measured on one long-lived install, per project (blocking rows / seeded rows):

```
25/363 · 17/302 · 13/448 · 10/148 · 4/179 · 2/245 · 2/122
7 of 40 projects affected
```

A fresh install has none, which is likely why this hasn't surfaced — it needs merge/curate history plus an eventual hard delete. Detection query is in #377 if you want to check other installs.

## Tests

Two regression tests in `rust-mode-transform.test.ts`, both red-checked:

1. drops a pointer whose target is absent from the seed set, **and preserves a resolvable one in the same seed** — guards against a blanket-null regression
2. drops a pointer whose target belongs to another project

`authoritySeedRows` is added to the existing `__rustModeTransformTest` export surface; no other production surface changed. In-memory DB, no `mock.module` (avoiding the process-global bleed of #279).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/magic-context/pr/378"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790533896&installation_model_id=22398&pr_number=378&repository=cortexkit%2Fmagic-context&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Fmagic-context%2Fpull%2F378&signature=bbbad3fa554da777a411e10c39dc159d197b48721acfb6f69a61c2c0c450ed86"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes rust mode being permanently unreachable when a memory's `superseded_by_memory_id` points to a row that was hard-deleted after being archived. The seed set no longer includes that target, so the Rust store records an unresolvable pending reference and rejects the handoff. Host now drops such dead pointers before seeding, while keeping resolvable ones intact.

- Drops any supersede pointer whose target is absent from the seed set, including cross-project targets.
- Preserves resolvable pointers; verified to drop only the dead links (61 of 63 preserved on an affected project).
- Adds two regression tests covering both cases.
- Fixes #377.

<sup>Written for commit a0f548c0a189dd69ad6f2c90c7a35bac203b4ba5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/magic-context/pull/378?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR prevents permanently unresolved Rust authority references by clearing supersession pointers whose targets are absent from the complete project-scoped seed set.
- Builds the set of memory IDs included in each authority handoff.
- Preserves resolvable supersession relationships while nulling only out-of-seed targets.
- Adds regression coverage for deleted/missing and cross-project targets.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no actionable correctness or security issues identified.

The project-scoped seed is complete before transport batching, valid in-seed supersession references are preserved, and host and module checksums operate on the same transformed snapshots.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/plugin/src/hooks/magic-context/rust-mode-transform.ts | Filters unresolvable supersession pointers at the host boundary while preserving targets included in the complete project seed. |
| packages/plugin/src/hooks/magic-context/rust-mode-transform.test.ts | Covers missing and cross-project targets and verifies that valid same-seed pointers remain intact. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Load all project memories] --> B[Build seeded ID set]
  B --> C{Supersession target included?}
  C -->|Yes| D[Preserve pointer]
  C -->|No| E[Set pointer to null]
  D --> F[Seed Rust authority]
  E --> F
  F --> G[Complete authority handoff]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(rust): drop supersede pointers outsi..."](https://github.com/cortexkit/magic-context/commit/a0f548c0a189dd69ad6f2c90c7a35bac203b4ba5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58013350)</sub>

**Context used:**

- Knowledge Base — [Memory storage and decay](https://app.greptile.com/cortexkit/-/custom-context/knowledge-base/cortexkit/magic-context/-/docs/memory-storage.md)

<!-- /greptile_comment -->