### PR TITLE
fix(test): resolve the store version from the upstream lane in persistedVersion

### DIFF
--- a/packages/plugin/src/features/magic-context/storage-db-initialize-order.test.ts
+++ b/packages/plugin/src/features/magic-context/storage-db-initialize-order.test.ts
@@ -6,7 +6,12 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Database } from "../../shared/sqlite";
 import { closeQuietly } from "../../shared/sqlite-helpers";
-import { LATEST_MIGRATION_VERSION, MIGRATIONS, runMigrations } from "./migrations";
+import {
+    FORK_MIGRATION_VERSION_FLOOR,
+    LATEST_MIGRATION_VERSION,
+    MIGRATIONS,
+    runMigrations,
+} from "./migrations";
 import { closeDatabase, initializeDatabase, openDatabase, openDatabaseAsync } from "./storage-db";
 
 interface InitializerIndexAudit {
@@ -137,8 +142,16 @@ function seedHistoricalStoreFile(version: number): { dir: string; path: string }
 }
 
 function persistedVersion(db: Database): number {
+    // Mirror getPersistedSchemaVersion: rows at or above the reserved fork lane are a
+    // downstream namespace, not this binary's schema version. A bare MAX(version) reads
+    // a fork's 10_000+ row as the store version, so this assertion fails for any fork
+    // using the documented lane even though production resolves the version correctly.
     return (
-        db.prepare("SELECT COALESCE(MAX(version), 0) AS version FROM schema_migrations").get() as {
+        db
+            .prepare(
+                "SELECT COALESCE(MAX(version), 0) AS version FROM schema_migrations WHERE version < ?",
+            )
+            .get(FORK_MIGRATION_VERSION_FLOOR) as {
             version: number;
         }
     ).version;
@@ -231,6 +244,28 @@ describe("initializeDatabase legacy index ordering", () => {
             } finally {
                 closeQuietly(db);
             }
+        }
+    });
+
+    test("resolves the store version from the upstream lane when a fork migration row is present", () => {
+        const seeded = seedHistoricalStoreFile(6);
+        try {
+            const db = openDatabase(seeded.path);
+            expect(db).not.toBeNull();
+            // A downstream fork records its own migrations in the reserved >= 10_000 lane.
+            db!
+                .prepare(
+                    // OR REPLACE so the fixture is idempotent on a real fork, whose own
+                    // migration may already occupy this version.
+                    "INSERT OR REPLACE INTO schema_migrations (version, description, applied_at) VALUES (?, ?, ?)",
+                )
+                .run(FORK_MIGRATION_VERSION_FLOOR + 100, "downstream fork migration", Date.now());
+            // The store version is still this binary's latest upstream migration; the fork
+            // row is a separate namespace and must never be read as the schema version.
+            expect(persistedVersion(db!)).toBe(LATEST_MIGRATION_VERSION);
+        } finally {
+            closeDatabase();
+            rmSync(seeded.dir, { recursive: true, force: true });
         }
     });
 });


### PR DESCRIPTION
## What

`persistedVersion` in `storage-db-initialize-order.test.ts` reads the store's schema version with a bare `MAX(version)`. Production doesn't — `getPersistedSchemaVersion` bounds the same read by the reserved fork lane:

```ts
// storage-db.ts:269-274
const row = db
    .prepare("SELECT COALESCE(MAX(version), 0) AS version FROM schema_migrations WHERE version < ?")
    .get(FORK_MIGRATION_VERSION_FLOOR) as { version: number } | undefined;
```

So for a downstream fork recording its migrations in the documented `>= 10_000` lane, production resolves the version correctly while this test helper reads the fork's row as the store version:

```
opens the repaired legacy store through the shared OpenCode and Pi boot paths
  Expected: 82
  Received: 10100
```

The test is correct in what it asserts — it's the helper that doesn't match the production rule it's standing in for.

## Change

Mirror the production bound in the helper, plus a regression that seeds a fork-lane row and asserts the resolved version is still `LATEST_MIGRATION_VERSION`.

Red-check: reverting the helper bound while keeping the new test gives `Expected: 82 / Received: 10100` — the same symptom, now caught directly rather than as a side effect of an unrelated boot-path assertion.

```
with the fix              5 pass / 0 fail
helper reverted, test kept 4 pass / 1 fail
```

## Scope

One test file, +35/−2. No production code touched.

`tsc --noEmit` clean. Lint reports the same 6 pre-existing errors as clean `master` (verified by stashing), none in this file.

## Why it matters

This is the only place I found where the reserved-lane convention from #280 isn't honoured. Production code, the schema fence, and the migration runner all respect the floor; this helper was the one straggler. Without it, any fork using the lane as documented sees a red suite on an upstream test that has nothing to do with its changes — which is exactly the friction the reserved lane was introduced to remove.

Found while rebasing a fork onto `master` after #376/#378 merged: the failure looked like one of the known full-suite concurrency artifacts, but it reproduced in isolation (2.6s, single file) and passed on clean `master`, which is what pointed at the helper rather than the environment.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/magic-context/pr/382"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790546500&installation_model_id=22398&pr_number=382&repository=cortexkit%2Fmagic-context&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Fmagic-context%2Fpull%2F382&signature=75fb5045bb5a179165db048b714e64e27c941e93752865204132521672f3ddbe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `persistedVersion` test helper so it resolves the store version from the upstream migration lane, matching production's `getPersistedSchemaVersion`. Previously the helper used a bare `MAX(version)` query, so a downstream fork recording migrations in the reserved `10_000+` lane was treated as the store version and failed the shared boot assertion.

- Adds a regression test that seeds a fork-lane row and asserts the resolved version is still `LATEST_MIGRATION_VERSION`.

<sup>Written for commit 2580291fe0455c997394bc38a2e449af12f8b604. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/magic-context/pull/382?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR aligns the test-only `persistedVersion` helper with production by excluding migration rows in the reserved downstream-fork lane.

- Imports and applies `FORK_MIGRATION_VERSION_FLOOR` to the helper query.
- Adds regression coverage proving a fork-lane row does not change the resolved upstream schema version.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no actionable defects identified in the test-only change.

The updated query uses the same constant and strict boundary as production, while the regression fixture remains isolated and is cleaned up through the existing database lifecycle.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/plugin/src/features/magic-context/storage-db-initialize-order.test.ts | The helper now mirrors production’s bounded schema-version query, and the added isolated regression test correctly covers the downstream fork-lane case. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(test): resolve the store version fro..."](https://github.com/cortexkit/magic-context/commit/2580291fe0455c997394bc38a2e449af12f8b604) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58082791)</sub>

<!-- /greptile_comment -->