### PR TITLE
Animate the in_progress todo glyph on wall clock

### DIFF
--- a/packages/pi-plugin/src/tools/todo-view-pi.ts
+++ b/packages/pi-plugin/src/tools/todo-view-pi.ts
@@ -265,6 +265,14 @@ function lineComponent(renderLines: (width: number) => string[]): Component {
 	};
 }
 
+function hasAnimatedRow(
+	rows: ReadonlyArray<{ todo: TodoItem; key: string }>,
+): boolean {
+	return capTodoRows(rows).visible.some(
+		({ todo }) => todo.status === "in_progress",
+	);
+}
+
 function capTodoRows<T>(rows: readonly T[]): {
 	visible: T[];
 	hiddenCount: number;
@@ -467,9 +475,9 @@ export class TodoOverlay {
 				{ placement: "aboveEditor" },
 			);
 			this.widgetRegistered = true;
-			this.syncSpinTimer(visible.some((todo) => todo.status === "in_progress"));
+			this.syncSpinTimer(hasAnimatedRow(visible));
 		} else {
-			this.syncSpinTimer(visible.some((todo) => todo.status === "in_progress"));
+			this.syncSpinTimer(hasAnimatedRow(visible));
 			this.tui?.requestRender();
 		}
 	}

--- a/packages/pi-plugin/src/tools/todo-view-pi.ts
+++ b/packages/pi-plugin/src/tools/todo-view-pi.ts
@@ -59,6 +59,11 @@ const STATUS_COLOR: Record<TodoStatus, Parameters<Theme["fg"]>[0]> = {
 	cancelled: "error",
 };
 
+const SPIN_FRAMES = ["◐", "◓", "◑", "◒"];
+function spinGlyph(): string {
+	return SPIN_FRAMES[Math.floor(Date.now() / 160) % SPIN_FRAMES.length]!;
+}
+
 const snapshotsBySession = new Map<string, TodoSnapshot>();
 const MAX_TODOWRITE_RENDER_CACHE_ENTRIES = 50;
 
@@ -236,7 +241,7 @@ function formatTodoLine(
 	theme: Theme,
 	options: { showId?: boolean } = {},
 ): string {
-	const glyph = theme.fg(STATUS_COLOR[todo.status], STATUS_GLYPH[todo.status]);
+	const glyph = theme.fg(STATUS_COLOR[todo.status], todo.status === "in_progress" ? spinGlyph() : STATUS_GLYPH[todo.status]);
 	const id =
 		options.showId && todo.id ? `${theme.fg("accent", `#${todo.id}`)} ` : "";
 	const color =
@@ -388,6 +393,7 @@ function isOverlayLive(todo: TodoItem): boolean {
 }
 
 export class TodoOverlay {
+	private spinTimer: ReturnType<typeof setInterval> | undefined;
 	private uiCtx: ExtensionUIContext | undefined;
 	private sessionId: string | undefined;
 	private widgetRegistered = false;
@@ -420,6 +426,7 @@ export class TodoOverlay {
 				this.uiCtx.setWidget(WIDGET_KEY, undefined);
 				this.widgetRegistered = false;
 				this.tui = undefined;
+				if (this.spinTimer) { clearInterval(this.spinTimer); this.spinTimer = undefined; }
 			}
 			return;
 		}
@@ -438,12 +445,21 @@ export class TodoOverlay {
 						invalidate: () => {
 							this.widgetRegistered = false;
 							this.tui = undefined;
+							if (this.spinTimer) { clearInterval(this.spinTimer); this.spinTimer = undefined; }
 						},
 					};
 				},
 				{ placement: "aboveEditor" },
 			);
 			this.widgetRegistered = true;
+			if (!this.spinTimer) {
+				// Wall-clock repaint so the in_progress glyph animates between
+				// todowrite events; cleared whenever the widget unmounts.
+				this.spinTimer = setInterval(() => {
+					this.tui?.requestRender();
+				}, 160);
+				this.spinTimer.unref?.();
+			}
 		} else {
 			this.tui?.requestRender();
 		}
@@ -470,6 +486,7 @@ export class TodoOverlay {
 	}
 
 	dispose(): void {
+		if (this.spinTimer) { clearInterval(this.spinTimer); this.spinTimer = undefined; }
 		if (this.uiCtx) this.uiCtx.setWidget(WIDGET_KEY, undefined);
 		this.widgetRegistered = false;
 		this.tui = undefined;

--- a/packages/pi-plugin/src/tools/todo-view-pi.ts
+++ b/packages/pi-plugin/src/tools/todo-view-pi.ts
@@ -394,6 +394,21 @@ function isOverlayLive(todo: TodoItem): boolean {
 
 export class TodoOverlay {
 	private spinTimer: ReturnType<typeof setInterval> | undefined;
+	private syncSpinTimer(hasInProgress: boolean): void {
+		if (hasInProgress && this.widgetRegistered) {
+			if (this.spinTimer) return;
+			// Wall-clock repaint so the in_progress glyph animates between
+			// todowrite events; keyed on the presence of an in_progress todo so
+			// an overlay of pending/completed rows costs nothing.
+			this.spinTimer = setInterval(() => {
+				this.tui?.requestRender();
+			}, 160);
+			this.spinTimer.unref?.();
+		} else if (this.spinTimer) {
+			clearInterval(this.spinTimer);
+			this.spinTimer = undefined;
+		}
+	}
 	private uiCtx: ExtensionUIContext | undefined;
 	private sessionId: string | undefined;
 	private widgetRegistered = false;
@@ -452,15 +467,9 @@ export class TodoOverlay {
 				{ placement: "aboveEditor" },
 			);
 			this.widgetRegistered = true;
-			if (!this.spinTimer) {
-				// Wall-clock repaint so the in_progress glyph animates between
-				// todowrite events; cleared whenever the widget unmounts.
-				this.spinTimer = setInterval(() => {
-					this.tui?.requestRender();
-				}, 160);
-				this.spinTimer.unref?.();
-			}
+			this.syncSpinTimer(visible.some((todo) => todo.status === "in_progress"));
 		} else {
+			this.syncSpinTimer(visible.some((todo) => todo.status === "in_progress"));
 			this.tui?.requestRender();
 		}
 	}


### PR DESCRIPTION
The todo overlay's `◐` in-progress glyph is static — the widget only repaints on todowrite events, so during a long-running step the overlay reads as frozen even though work is happening.

This PR makes the in-progress glyph a lightweight spinner:

- `in_progress` cycles `◐ ◓ ◑ ◒` derived from `Date.now() / 160` (~6 fps wall clock) — pending/completed/cancelled glyphs unchanged.
- One `unref()`'d 160ms interval drives `requestRender`, created only when the widget mounts and cleared on unmount, factory `invalidate`, and `dispose` — an overlay with no visible todos costs nothing, and the timer can't hold the process open.

Running it locally: the active todo visibly spins while agents work, which reads much better than the frozen half-circle during quiet stretches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/magic-context/pr/383"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790555360&installation_model_id=22398&pr_number=383&repository=cortexkit%2Fmagic-context&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Fmagic-context%2Fpull%2F383&signature=e7378302261ff744078c1b39a0891ae250f1a573141e99d2d518039ec92cb47d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Animates the in-progress todo glyph so the overlay no longer looks frozen during long-running steps. The glyph now cycles ◐ ◓ ◑ ◒ on a wall clock (~6fps) instead of staying static until the next todowrite event.

- Drives the animation with a single unref'd 160ms interval that runs only while a painted in_progress row is visible, using the same cap the renderer applies; an overlay of pending/completed rows costs nothing.
- Clears the timer when no in_progress todos remain, and on unmount, factory `invalidate`, and `dispose`.
- Pending, completed, and cancelled glyphs are unchanged.

<sup>Written for commit 9d11335182eea73970e58ba6349c7676ac241a33. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/magic-context/pull/383?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR animates visible in-progress todo glyphs using a wall-clock-driven repaint timer and limits that timer to periods when an animated row is actually painted.
- Adds four-frame rendering for the `in_progress` glyph.
- Starts the repaint timer only when a visible, capped todo row is in progress.
- Clears the timer when the overlay becomes static, is invalidated, or is disposed.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/pi-plugin/src/tools/todo-view-pi.ts | Adds spinner rendering and lifecycle-managed repaint scheduling; the current visibility check resolves the previously reported static-overlay repaint issue. |

</details>

<sub>Reviews (3): Last reviewed commit: ["Gate the spin timer on a painted in\_prog..."](https://github.com/cortexkit/magic-context/commit/9d11335182eea73970e58ba6349c7676ac241a33) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58120899)</sub>

<!-- /greptile_comment -->