### PR TITLE
fix(historian): stop sending temperature to reasoning models

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -663,7 +663,7 @@ It is useful when starting a new session. It's better to choose a fast and cheap
 |-------|------|-------------|
 | `model` | `string` | Primary model. |
 | `fallback_models` | `string` or `string[]` | Fallback models. |
-| `temperature` | `number` (0–2) | Sampling temperature. |
+| `temperature` | `number` (0–2) | Sampling temperature. Omitted by default: no `temperature` is sent to the provider unless you set one. Reasoning models reject the parameter outright, so only set it for models that accept it. |
 | `variant` | `string` | **OpenCode only.** Agent variant — selects a thinking/reasoning preset. Pi uses `thinking_level` instead. |
 | `thinking_level` | `string` | **Pi only.** Explicit reasoning level (`off`/`low`/`medium`/`high`) passed to Pi for sidekick subagent runs. See `historian.thinking_level`. |
 | `prompt` | `string` | Persistent agent-level system prompt override. Applies to every sidekick run. |

--- a/packages/pi-plugin/src/historian-calibration-extension.test.ts
+++ b/packages/pi-plugin/src/historian-calibration-extension.test.ts
@@ -42,4 +42,56 @@ describe("historian provider calibration", () => {
 			),
 		).toEqual({ inferenceConfig: { temperature: 0.1, maxTokens: 32_000 } });
 	});
+
+	it("never sends temperature when it is not configured", () => {
+		const fixtures = [
+			{ input: { max_tokens: 4096 }, key: "max_tokens" },
+			{ input: { max_completion_tokens: 4096 }, key: "max_completion_tokens" },
+			{ input: { max_output_tokens: 4096 }, key: "max_output_tokens" },
+			{ input: { maxTokens: 4096 }, key: "maxTokens" },
+		] as const;
+		for (const fixture of fixtures) {
+			const result = calibrateHistorianProviderPayload(
+				fixture.input,
+				undefined,
+				32_000,
+			) as Record<string, unknown>;
+			expect("temperature" in result).toBe(false);
+			expect(result[fixture.key]).toBe(32_000);
+		}
+	});
+
+	it("omits temperature from nested provider shapes when unconfigured", () => {
+		expect(
+			calibrateHistorianProviderPayload(
+				{ generationConfig: { topP: 0.9, maxOutputTokens: 4096 } },
+				undefined,
+				32_000,
+			),
+		).toEqual({ generationConfig: { topP: 0.9, maxOutputTokens: 32_000 } });
+		expect(
+			calibrateHistorianProviderPayload(
+				{ inferenceConfig: { maxTokens: 4096 } },
+				undefined,
+				32_000,
+			),
+		).toEqual({ inferenceConfig: { maxTokens: 32_000 } });
+	});
+
+	it("applies temperature alone when no output budget is configured", () => {
+		const result = calibrateHistorianProviderPayload(
+			{ max_tokens: 4096 },
+			0.1,
+			undefined,
+		) as Record<string, unknown>;
+		expect(result.temperature).toBe(0.1);
+		expect(result.max_tokens).toBe(4096);
+	});
+
+	it("returns the payload untouched when neither knob is configured", () => {
+		const payload = { max_tokens: 4096 };
+		expect(
+			calibrateHistorianProviderPayload(payload, undefined, undefined),
+		).toEqual({ max_tokens: 4096 });
+	});
 });

--- a/packages/pi-plugin/src/historian-calibration-extension.ts
+++ b/packages/pi-plugin/src/historian-calibration-extension.ts
@@ -10,13 +10,21 @@ function finiteNumber(value: string | undefined): number | undefined {
 	return Number.isFinite(parsed) && parsed >= 0 ? parsed : undefined;
 }
 
-/** Apply the historian calibration to each provider's serialized request shape. */
+/**
+ * Apply the historian calibration to each provider's serialized request shape.
+ *
+ * Both knobs are optional and applied independently: reasoning models reject
+ * `temperature` outright, so an output-token budget must still be applicable
+ * on its own.
+ */
 export function calibrateHistorianProviderPayload(
 	payload: unknown,
-	temperature: number,
-	maxOutputTokens: number,
+	temperature: number | undefined,
+	maxOutputTokens: number | undefined,
 ): unknown {
 	if (typeof payload !== "object" || payload === null || Array.isArray(payload))
+		return payload;
+	if (temperature === undefined && maxOutputTokens === undefined)
 		return payload;
 	const calibrated = { ...(payload as Record<string, unknown>) };
 	const generationConfig = calibrated.generationConfig;
@@ -27,8 +35,8 @@ export function calibrateHistorianProviderPayload(
 	) {
 		calibrated.generationConfig = {
 			...(generationConfig as Record<string, unknown>),
-			temperature,
-			maxOutputTokens,
+			...(temperature !== undefined ? { temperature } : {}),
+			...(maxOutputTokens !== undefined ? { maxOutputTokens } : {}),
 		};
 		return calibrated;
 	}
@@ -40,21 +48,25 @@ export function calibrateHistorianProviderPayload(
 	) {
 		calibrated.inferenceConfig = {
 			...(inferenceConfig as Record<string, unknown>),
-			temperature,
-			maxTokens: maxOutputTokens,
+			...(temperature !== undefined ? { temperature } : {}),
+			...(maxOutputTokens !== undefined ? { maxTokens: maxOutputTokens } : {}),
 		};
 		return calibrated;
 	}
 
-	calibrated.temperature = temperature;
-	if ("max_output_tokens" in calibrated) {
-		calibrated.max_output_tokens = maxOutputTokens;
-	} else if ("max_completion_tokens" in calibrated) {
-		calibrated.max_completion_tokens = maxOutputTokens;
-	} else if ("max_tokens" in calibrated) {
-		calibrated.max_tokens = maxOutputTokens;
-	} else if ("maxTokens" in calibrated) {
-		calibrated.maxTokens = maxOutputTokens;
+	if (temperature !== undefined) {
+		calibrated.temperature = temperature;
+	}
+	if (maxOutputTokens !== undefined) {
+		if ("max_output_tokens" in calibrated) {
+			calibrated.max_output_tokens = maxOutputTokens;
+		} else if ("max_completion_tokens" in calibrated) {
+			calibrated.max_completion_tokens = maxOutputTokens;
+		} else if ("max_tokens" in calibrated) {
+			calibrated.max_tokens = maxOutputTokens;
+		} else if ("maxTokens" in calibrated) {
+			calibrated.maxTokens = maxOutputTokens;
+		}
 	}
 	return calibrated;
 }
@@ -64,7 +76,7 @@ export default function historianCalibrationExtension(pi: ExtensionAPI): void {
 	const maxOutputTokens = finiteNumber(
 		process.env[HISTORIAN_MAX_OUTPUT_TOKENS_ENV],
 	);
-	if (temperature === undefined || maxOutputTokens === undefined) return;
+	if (temperature === undefined && maxOutputTokens === undefined) return;
 	pi.on("before_provider_request", (event) =>
 		calibrateHistorianProviderPayload(
 			event.payload,

--- a/packages/pi-plugin/src/index.ts
+++ b/packages/pi-plugin/src/index.ts
@@ -703,7 +703,7 @@ export function resolveHistorianFromConfig(
 		fallbackModels,
 		historianChunkTokens,
 		timeoutMs: config.historian_timeout_ms,
-		temperature: historian?.temperature ?? 0.1,
+		temperature: historian?.temperature,
 		maxOutputTokens: historian?.maxTokens ?? 32_000,
 		// `historian.two_pass` runs an editor pass after a successful
 		// first pass to clean low-signal U: lines and cross-compartment

--- a/packages/pi-plugin/src/pi-historian-runner.ts
+++ b/packages/pi-plugin/src/pi-historian-runner.ts
@@ -444,7 +444,7 @@ export async function runPiHistorian(deps: PiHistorianDeps): Promise<void> {
 		refreshBoundarySnapshot,
 		currentContextLimit,
 		historianTimeoutMs = DEFAULT_HISTORIAN_TIMEOUT_MS,
-		temperature = 0.1,
+		temperature,
 		maxOutputTokens = 32_000,
 		signal,
 		retryBackoffMs,

--- a/packages/pi-plugin/src/subagent-runner.test.ts
+++ b/packages/pi-plugin/src/subagent-runner.test.ts
@@ -1558,6 +1558,34 @@ describe("PiSubagentRunner spawn lifecycle", () => {
 		});
 	});
 
+	it("surfaces the provider error behind empty assistant text", async () => {
+		const child = createMockChild();
+		const { runner } = runnerWith(child);
+
+		const resultPromise = runner.run(baseOptions);
+		child.writeStdoutLine(
+			agentEnd([
+				{
+					role: "assistant",
+					content: [],
+					stopReason: "error",
+					errorMessage:
+						"OpenAI API error (400): Unsupported parameter: temperature",
+				},
+			]),
+		);
+		child.emitClose(0);
+
+		expect(await resultPromise).toEqual({
+			ok: false,
+			reason: "no_assistant",
+			error:
+				"pi assistant produced empty text (provider error: OpenAI API error (400): Unsupported parameter: temperature)",
+			durationMs: expect.any(Number),
+			meta: { stderr: undefined, sawProtocolOutput: true },
+		});
+	});
+
 	it("returns no_assistant for empty stdout and successful exit", async () => {
 		// Issue #238: an empty-stdout exit-0 primary now fires the one-shot
 		// isolated retry. When the isolated attempt ALSO exits 0 with no output,

--- a/packages/pi-plugin/src/subagent-runner.ts
+++ b/packages/pi-plugin/src/subagent-runner.ts
@@ -1378,13 +1378,16 @@ export class PiSubagentRunner implements SubagentRunner {
 						trimmedAssistantText === null ||
 						trimmedAssistantText.length === 0
 					) {
+						const emptyAssistantReason =
+							trimmedAssistantText === null
+								? "pi agent_end did not include an assistant message"
+								: "pi assistant produced empty text";
 						settle({
 							ok: false,
 							reason: "no_assistant",
-							error:
-								trimmedAssistantText === null
-									? "pi agent_end did not include an assistant message"
-									: "pi assistant produced empty text",
+							error: finalErrorMessage
+								? `${emptyAssistantReason} (provider error: ${finalErrorMessage})`
+								: emptyAssistantReason,
 							durationMs: Date.now() - startTime,
 							// Pi machinery worked (agent_end / terminal message_end seen);
 							// the model just returned empty text. Mark protocol output as


### PR DESCRIPTION
## Problem

Every historian run fails with `no_assistant: pi assistant produced empty text` when the historian model is a reasoning/thinking model. The plugin reports this as a misconfigured or unreachable historian model, so the warning tells the user to check `magic-context.jsonc` — but the model and the endpoint are both healthy.

The real failure is an HTTP 400 from the provider, caused by the plugin itself:

| Provider / model | Response to the injected `temperature` |
|---|---|
| OpenAI Responses (`gpt-5.x` reasoning) | `400 Unsupported parameter: temperature` |
| Anthropic (`claude-*` with thinking) | `400 \`temperature\` may only be set to 1 when thinking is enabled or in adaptive mode` |

Because the provider rejects the request, pi emits `agent_end` with an empty assistant message, and `extractFinalAssistant()` reports empty text. Every configured fallback model fails the same way, since the cause is the request shape rather than the model.

The three defaults responsible were introduced together in `10f80e58` ("mason: close producer and maintenance parity"), first released in `v0.41.0` — the only tag that contains that commit. In my case a healthy setup went from 16 consecutive successful compartings to 32 consecutive failures immediately after upgrading.

## Reproduction

```sh
MAGIC_CONTEXT_HISTORIAN_TEMPERATURE=0.1 \
MAGIC_CONTEXT_HISTORIAN_MAX_OUTPUT_TOKENS=32000 \
pi --print --mode json --no-session --no-skills \
   --extension dist/historian-calibration-extension.js \
   --model <reasoning-model> --thinking max "Reply with exactly: PONG"
```

Yields `stopReason: "error"`, `content: []`, and `errorMessage: "OpenAI API error (400): Unsupported parameter: temperature"`. Dropping the temperature env var makes the identical command return normal text.

## Root cause

`temperature` is defaulted to `0.1` in two independent places, so the historian always sends it even when the user never configured one:

- `packages/pi-plugin/src/index.ts` — `temperature: historian?.temperature ?? 0.1`
- `packages/pi-plugin/src/pi-historian-runner.ts` — `temperature = 0.1` destructuring default

Removing only the first is not enough; the runner default silently reapplies `0.1`.

`historian-calibration-extension.ts` also treats the two knobs as a single unit (`if (temperature === undefined || maxOutputTokens === undefined) return`), so an output-token budget cannot be applied unless a temperature is supplied too.

## Why the 400 was invisible

In `subagent-runner.ts`, the empty-assistant-text branch is evaluated **before** the `finalStopReason === "error"` branch. A provider error whose message carries no text therefore always settles as `no_assistant`, and the captured `finalErrorMessage` holding the real 400 is discarded. The user only ever sees "produced empty text".

## Changes

- `temperature` is now opt-in. When it is not configured, no `temperature` is sent to the provider at all — restoring the request shape used before `v0.41.0`. Users whose models accept it can still set `historian.temperature`.
- `temperature` and `maxOutputTokens` are applied independently, so the 32k output budget still works on its own. This keeps the calibration feature intact for reasoning models, which is where the output budget matters most.
- The `no_assistant` failure now appends the provider error message when one was captured, so a rejected request is diagnosable instead of being reported as an empty model response.
- `CONFIGURATION.md` documents the opt-in behaviour and the reasoning-model constraint.

No config migration is required: existing configs that set `historian.temperature` explicitly keep their exact behaviour.

## Tests

- 4 new cases in `historian-calibration-extension.test.ts` covering unset temperature, nested provider shapes, temperature without an output budget, and neither knob set.
- 1 new regression test in `subagent-runner.test.ts` asserting the provider error survives into the failure message.
- Verified with a negative control: reverting only the `subagent-runner.ts` change fails exactly that one test (86 pass / 1 fail), and passes with it (87 pass).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/magic-context/pr/399"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790751781&installation_model_id=22398&pr_number=399&repository=cortexkit%2Fmagic-context&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Fmagic-context%2Fpull%2F399&signature=614b523487f0ebf29f2d58a1de8d4d9c51d2fe30af3f5d03c8e5ef23049aaf84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the historian from always sending `temperature` to providers, which caused reasoning models to reject requests with HTTP 400 and surface as a misleading `no_assistant` error. Temperature is now opt-in: if unconfigured, no `temperature` is sent at all.

**Bug Fixes**
- `temperature` and `maxOutputTokens` are now applied independently, so the output-token budget still works on its own.
- `no_assistant` failures append the captured provider error so rejected requests are diagnosable.
- No config migration is needed; existing configs that set `historian.temperature` behave exactly as before.

<sup>Written for commit 55ad3d123e047b47895da0842401a027ddb9d1ed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/magic-context/pull/399?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR makes Pi historian temperature opt-in while preserving independent output-token calibration, and improves diagnostics when a provider error accompanies an empty assistant response.
- Removes the implicit `0.1` temperature from configuration resolution and historian execution.
- Applies temperature and output-token limits independently across supported provider payload shapes.
- Includes captured provider errors in empty-assistant failures.
- Adds regression coverage and documents reasoning-model compatibility.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge; no concrete changed-code failure remains after tracing configuration propagation, payload calibration, and fallback handling.

Unconfigured temperature is omitted from the child environment, the output-token budget remains independently applied, explicit temperatures continue to propagate, and enriched empty-response diagnostics preserve existing fallback behavior.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/pi-plugin/src/historian-calibration-extension.ts | Makes both calibration knobs independently optional while preserving the recognized top-level and nested provider mappings. |
| packages/pi-plugin/src/index.ts | Stops synthesizing a historian temperature when the shared configuration omits it. |
| packages/pi-plugin/src/pi-historian-runner.ts | Removes the runner-level temperature fallback so omission survives through all historian model attempts. |
| packages/pi-plugin/src/subagent-runner.ts | Preserves captured provider diagnostics when terminal protocol output contains no assistant text without changing fallback eligibility. |
| packages/pi-plugin/src/historian-calibration-extension.test.ts | Covers independent calibration, nested payloads, omitted temperature, and the no-calibration case. |
| packages/pi-plugin/src/subagent-runner.test.ts | Verifies that provider error details survive the empty-assistant failure path. |
| CONFIGURATION.md | Documents temperature as opt-in and warns that reasoning models may reject it. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(subagent): surface provider error be..."](https://github.com/cortexkit/magic-context/commit/55ad3d123e047b47895da0842401a027ddb9d1ed) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58536633)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Pi plugin runtime](https://app.greptile.com/cortexkit/-/custom-context/knowledge-base/cortexkit/magic-context/-/docs/pi-plugin.md)
- Knowledge Base — [Historian production flow](https://app.greptile.com/cortexkit/-/custom-context/knowledge-base/cortexkit/magic-context/-/docs/historian-production.md)
- Knowledge Base — [Configuration and harness compatibility](https://app.greptile.com/cortexkit/-/custom-context/knowledge-base/cortexkit/magic-context/-/docs/configuration-and-compatibility.md)
</details>


<!-- /greptile_comment -->