### PR TITLE
feat(embedding): support dimensions for openai-compatible Matryoshka models (#405)

### DIFF
--- a/assets/magic-context.schema.json
+++ b/assets/magic-context.schema.json
@@ -1760,6 +1760,12 @@
           "exclusiveMinimum": 0,
           "maximum": 9007199254740991
         },
+        "dimensions": {
+          "description": "Optional embedding dimensions for Matryoshka models like Qwen3-Embedding (e.g. 768, 1024, 4096). When set, sent as dimensions in the embedding request body. Omitted keeps provider default.",
+          "type": "integer",
+          "exclusiveMinimum": 0,
+          "maximum": 8192
+        },
         "local_runtime": {
           "default": "auto",
           "description": "Local provider only: ONNX runtime selection. 'auto' uses native under Node and uses WASM under Bun versions before 1.4.0, where Bun's NAPI teardown race can panic on quit; native is restored automatically on Bun 1.4.0+. Set 'native' only to prefer speed while accepting that pre-1.4.0 Bun crash risk, or 'wasm' to avoid loading the native addon.",

--- a/packages/plugin/src/config/schema/magic-context.ts
+++ b/packages/plugin/src/config/schema/magic-context.ts
@@ -619,6 +619,15 @@ const BaseEmbeddingConfigSchema = z
             .describe(
                 "Optional maximum input tokens for chunk embeddings. Defaults conservatively to 512 when omitted.",
             ),
+        dimensions: z
+            .number()
+            .int()
+            .positive()
+            .max(8192)
+            .optional()
+            .describe(
+                "Optional embedding dimensions for Matryoshka models like Qwen3-Embedding (e.g. 768, 1024, 4096). When set, sent as dimensions in the embedding request body. Omitted keeps provider default.",
+            ),
         local_runtime: z
             .enum(["auto", "native", "wasm"])
             .default("auto")
@@ -683,6 +692,7 @@ export const EmbeddingConfigSchema = BaseEmbeddingConfigSchema.transform((data) 
             ...(inputType ? { input_type: inputType } : {}),
             ...(queryInputType ? { query_input_type: queryInputType } : {}),
             ...(truncate ? { truncate } : {}),
+            ...(data.dimensions ? { dimensions: data.dimensions } : {}),
             ...(data.max_input_tokens ? { max_input_tokens: data.max_input_tokens } : {}),
         };
     }
@@ -716,6 +726,7 @@ export const EmbeddingConfigSchema = BaseEmbeddingConfigSchema.transform((data) 
             ...(inputType ? { input_type: inputType } : {}),
             ...(queryInputType ? { query_input_type: queryInputType } : {}),
             ...(truncate ? { truncate } : {}),
+            ...(data.dimensions ? { dimensions: data.dimensions } : {}),
             ...(data.max_input_tokens ? { max_input_tokens: data.max_input_tokens } : {}),
         };
     }

--- a/packages/plugin/src/features/magic-context/memory/embedding-identity.ts
+++ b/packages/plugin/src/features/magic-context/memory/embedding-identity.ts
@@ -34,6 +34,10 @@ export function getEmbeddingProviderIdentity(config: EmbeddingConfig): string {
     }
 
     const truncate = config.provider === "openai-compatible" ? config.truncate?.trim() : undefined;
+    const dimensions =
+        config.provider === "openai-compatible"
+            ? (config as unknown as { dimensions?: number }).dimensions
+            : undefined;
     // local_dtype changes the produced vectors (a quantized ONNX model emits
     // different embeddings than fp32), so a non-default dtype MUST fold into the
     // model identity — switching dtype re-embeds rather than mixing vector
@@ -66,6 +70,7 @@ export function getEmbeddingProviderIdentity(config: EmbeddingConfig): string {
                   // lazily GCs, never a destructive wipe).
                   inputType: config.input_type?.trim() || "",
                   ...(truncate ? { truncate } : {}),
+                  ...(dimensions ? { dimensions } : {}),
               }
             : {
                   provider: "local",

--- a/packages/plugin/src/features/magic-context/memory/embedding-openai.ts
+++ b/packages/plugin/src/features/magic-context/memory/embedding-openai.ts
@@ -15,6 +15,8 @@ interface OpenAICompatibleEmbeddingProviderOptions {
     queryInputType?: string;
     /** Optional `truncate` body field (e.g. NVIDIA NIM 'NONE'/'START'/'END'). */
     truncate?: string;
+    /** Optional `dimensions` body field for Matryoshka models like Qwen3-Embedding (e.g. 768, 1024, 4096). */
+    dimensions?: number;
     /** Maximum safe input tokens for chunk embeddings. */
     maxInputTokens?: number;
 }
@@ -142,6 +144,7 @@ export class OpenAICompatibleEmbeddingProvider implements EmbeddingProvider {
     private readonly inputType: string;
     private readonly queryInputType: string;
     private readonly truncate: string;
+    private readonly dimensions: number | undefined;
     private initialized = false;
 
     // Circuit breaker state (per provider instance — resets when config
@@ -166,6 +169,10 @@ export class OpenAICompatibleEmbeddingProvider implements EmbeddingProvider {
         this.inputType = options.inputType?.trim() ?? "";
         this.queryInputType = options.queryInputType?.trim() ?? "";
         this.truncate = options.truncate?.trim() ?? "";
+        this.dimensions =
+            typeof options.dimensions === "number" && Number.isFinite(options.dimensions)
+                ? Math.max(1, Math.floor(options.dimensions))
+                : undefined;
         this.maxInputTokens =
             typeof options.maxInputTokens === "number" && Number.isFinite(options.maxInputTokens)
                 ? Math.max(1, Math.floor(options.maxInputTokens))
@@ -182,6 +189,7 @@ export class OpenAICompatibleEmbeddingProvider implements EmbeddingProvider {
             // different model_id than reads/GC resolve, silently zeroing results
             // and reaping valid vectors.
             ...(this.truncate ? { truncate: this.truncate } : {}),
+            ...(this.dimensions ? { dimensions: this.dimensions } : {}),
         });
     }
 
@@ -300,6 +308,7 @@ export class OpenAICompatibleEmbeddingProvider implements EmbeddingProvider {
                     // unaffected.
                     ...(inputTypeForRequest ? { input_type: inputTypeForRequest } : {}),
                     ...(this.truncate ? { truncate: this.truncate } : {}),
+                    ...(this.dimensions ? { dimensions: this.dimensions } : {}),
                 }),
                 // SSRF: refuse to FOLLOW redirects. The pre-flight SSRF check only
                 // validates the configured endpoint; default redirect-follow would

--- a/packages/plugin/src/features/magic-context/memory/embedding.ts
+++ b/packages/plugin/src/features/magic-context/memory/embedding.ts
@@ -80,6 +80,7 @@ function resolveEmbeddingConfig(config?: EmbeddingConfig): EmbeddingConfig {
             ...(inputType ? { input_type: inputType } : {}),
             ...(queryInputType ? { query_input_type: queryInputType } : {}),
             ...(truncate ? { truncate } : {}),
+            ...(config.dimensions ? { dimensions: config.dimensions } : {}),
             ...(config.max_input_tokens
                 ? {
                       max_input_tokens: normalizeCompartmentChunkMaxInputTokens(
@@ -118,6 +119,7 @@ function createProvider(config: EmbeddingConfig): EmbeddingProvider | null {
             inputType: config.input_type,
             queryInputType: config.query_input_type,
             truncate: config.truncate,
+            dimensions: (config as unknown as { dimensions?: number }).dimensions,
             maxInputTokens: config.max_input_tokens,
         });
     }

--- a/packages/plugin/src/features/magic-context/project-embedding-registry.ts
+++ b/packages/plugin/src/features/magic-context/project-embedding-registry.ts
@@ -422,6 +422,7 @@ function resolveEmbeddingConfig(config?: EmbeddingConfig): EmbeddingConfig {
             ...(inputType ? { input_type: inputType } : {}),
             ...(queryInputType ? { query_input_type: queryInputType } : {}),
             ...(truncate ? { truncate } : {}),
+            ...(config.dimensions ? { dimensions: config.dimensions } : {}),
             ...(config.max_input_tokens
                 ? {
                       max_input_tokens: normalizeCompartmentChunkMaxInputTokens(
@@ -502,6 +503,7 @@ function createProvider(
             inputType: config.input_type,
             queryInputType: config.query_input_type,
             truncate: config.truncate,
+            dimensions: (config as unknown as { dimensions?: number }).dimensions,
             maxInputTokens: config.max_input_tokens,
         });
     }
@@ -585,6 +587,7 @@ function getChunkEmbeddingModelId(config: EmbeddingConfig, providerIdentity: str
             "max_input_tokens" in config ? config.max_input_tokens : undefined,
         ),
         truncate: config.provider === "openai-compatible" ? (config.truncate ?? "") : "",
+        dimensions: config.provider === "openai-compatible" ? ((config as unknown as { dimensions?: number }).dimensions ?? "") : "",
     };
     return `${providerIdentity}:chunk:${sha256Prefix(stableStringify(chunkIdentity))}`;
 }

--- a/packages/plugin/src/plugin/embedding-bootstrap-helpers.ts
+++ b/packages/plugin/src/plugin/embedding-bootstrap-helpers.ts
@@ -39,10 +39,11 @@ export const EMBEDDING_AFFECTING_KEYS = new Set([
     // not let a broken value re-register mid-session.
     "embedding.input_type",
     "embedding.truncate",
-    // max_input_tokens + query_input_type fold into the chunk-embedding identity
+    // max_input_tokens + query_input_type + dimensions fold into the chunk-embedding identity
     // (getChunkEmbeddingModelId); a failed substitution on either would otherwise
     // register as trusted and could drive a bogus chunk identity / GC.
     "embedding.max_input_tokens",
+    "embedding.dimensions",
     "embedding.query_input_type",
     "embedding.fallback_provider",
     "subc",

--- a/packages/plugin/src/plugin/embedding-routing.ts
+++ b/packages/plugin/src/plugin/embedding-routing.ts
@@ -53,6 +53,7 @@ function fallbackConfig(
     const queryInputType =
         typeof raw.query_input_type === "string" ? raw.query_input_type.trim() : "";
     const truncate = typeof raw.truncate === "string" ? raw.truncate.trim() : "";
+    const dimensions = typeof raw.dimensions === "number" ? raw.dimensions : undefined;
     const maxInputTokens =
         typeof raw.max_input_tokens === "number" ? raw.max_input_tokens : undefined;
 
@@ -66,6 +67,7 @@ function fallbackConfig(
             ...(inputType ? { input_type: inputType } : {}),
             ...(queryInputType ? { query_input_type: queryInputType } : {}),
             ...(truncate ? { truncate } : {}),
+            ...(dimensions !== undefined ? { dimensions } : {}),
             ...(maxInputTokens !== undefined ? { max_input_tokens: maxInputTokens } : {}),
         };
     }


### PR DESCRIPTION
Fixes #405

### Summary

Add optional `embedding.dimensions` for the `openai-compatible` provider to support Matryoshka models like `Qwen3-Embedding-8B` (768/1024/2048/4096 via `POST {dimensions}`).

Omitted keeps current behavior (byte-identical identity, no re-embed). Setting triggers per-model coexistence re-embed.

### Changes

- **Schema** `packages/plugin/src/config/schema/magic-context.ts`: `BaseEmbeddingConfigSchema.dimensions` (`max 8192`) + include in `EmbeddingConfigSchema.transform` for `openai-compatible`/`synapse`
- **Identity** `embedding-identity.ts`: `getEmbeddingProviderIdentity` folds `...dimensions?{dimensions}:{}`
- **Runtime** `embedding.ts` / `project-embedding-registry.ts`: `resolveEmbeddingConfig` preserves `dimensions`; `getChunkEmbeddingModelId` includes `dimensions`; `EMBEDDING_AFFECTING_KEYS` adds `embedding.dimensions`
- **Transport** `embedding-openai.ts`: `OpenAICompatibleEmbeddingProviderOptions.dimensions`, `this.dimensions`, `modelId` includes dimensions, `embedBatch` adds `...this.dimensions?{dimensions}:{}` to `POST /v1/embeddings`
- **Schema JSON** `assets/magic-context.schema.json` regenerated via `bun build-schema.ts` pattern (manual edit matching generator output)

Mirrors existing `truncate`/`input_type`/`local_dtype` conditional-fold pattern (#127, #155, #259).

### Testing

- Local `pi-magic-context@0.41.1` (Pi 0.84.4) with `Qwen3-Embedding-8B` via openai-compatible:
  - `no dimensions` → 768 (en) / 1024 (zh) dims
  - `dimensions:4096` → 16384 bytes / 4096 dims (`memory 2 → 0f395...`), verified via `memory_embeddings` and `embedding_registrations`
  - `doctor` passes; `build-schema` guard would pass after regeneration

### Checklist

- [x] Follows `truncate` fold pattern (conditional spread, no global re-embed when omitted)
- [x] Updates `EMBEDDING_AFFECTING_KEYS` for untrusted-load GC guard
- [x] Regenerates `assets/magic-context.schema.json`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/magic-context/pr/406"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790897503&installation_model_id=22398&pr_number=406&repository=cortexkit%2Fmagic-context&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Fmagic-context%2Fpull%2F406&signature=3fbf779af31f41037b71f87fdda770591842f92274642d185a2a1fbd7b3a0cf3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #405 by adding optional `embedding.dimensions` for the `openai-compatible` provider so Matryoshka models like `Qwen3-Embedding-8B` can be pinned to 768/1024/2048/4096. Omitting it keeps the current byte-identical identity; setting it sends `dimensions` in the `POST /v1/embeddings` body and folds it into the chunk identity, so changing it re-embeds existing vectors. The synapse fallback also carries dimensions so fallback requests and identities use the configured value instead of the provider default.

- Validates `dimensions` in the config schema with a max of 8192.
- Adds `embedding.dimensions` to `EMBEDDING_AFFECTING_KEYS` so config changes trip the GC guard on untrusted loads.
- Regenerates `assets/magic-context.schema.json`.

<sup>Written for commit 9f15915d28b85fd1cb440362eb96d4325b126bff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/magic-context/pull/406?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adds configurable output dimensions for OpenAI-compatible Matryoshka embedding models while preserving the existing provider-default behavior when omitted.
- Adds schema validation and generated JSON Schema coverage for `embedding.dimensions`.
- Includes configured dimensions in embedding identities so vector widths can coexist safely.
- Propagates dimensions through direct and Synapse fallback routing into OpenAI-compatible embedding requests.
- Treats dimensions as embedding-affecting configuration for registry and garbage-collection safeguards.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/plugin/src/config/schema/magic-context.ts | Adds bounded positive-integer validation and preserves dimensions for OpenAI-compatible and Synapse configurations. |
| packages/plugin/src/plugin/embedding-routing.ts | Completes the prior fix by carrying Synapse dimensions into OpenAI-compatible fallback configurations. |
| packages/plugin/src/features/magic-context/memory/embedding-openai.ts | Normalizes dimensions, includes them in provider identity, and sends them in embedding requests. |
| packages/plugin/src/features/magic-context/memory/embedding-identity.ts | Incorporates explicitly configured dimensions into OpenAI-compatible provider identities. |
| packages/plugin/src/features/magic-context/project-embedding-registry.ts | Preserves dimensions during registry resolution and includes them in chunk-model identity. |
| packages/plugin/src/plugin/embedding-bootstrap-helpers.ts | Marks dimensions as embedding-affecting configuration for guarded registry updates. |
| assets/magic-context.schema.json | Publishes the new optional dimensions field with the same validation constraints as the source schema. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    Config[Embedding configuration] --> Schema[Schema validation]
    Schema --> Routing{Provider routing}
    Routing -->|OpenAI-compatible| Resolve[Resolved embedding config]
    Routing -->|Synapse fallback| Fallback[OpenAI-compatible fallback config]
    Fallback --> Resolve
    Resolve --> Identity[Provider and chunk identities]
    Resolve --> Provider[OpenAI-compatible provider]
    Provider --> Request[POST /v1/embeddings with optional dimensions]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(embedding): propagate dimensions thr..."](https://github.com/cortexkit/magic-context/commit/9f15915d28b85fd1cb440362eb96d4325b126bff) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59280796)</sub>

**Context used:**

- Knowledge Base — [Configuration and harness compatibility](https://app.greptile.com/cortexkit/-/custom-context/knowledge-base/cortexkit/magic-context/-/docs/configuration-and-compatibility.md)

<!-- /greptile_comment -->