### PR TITLE
fix(pi): contain historian failures and busy-starved lease releases

### DIFF
--- a/packages/pi-plugin/src/commands/ctx-wrapup.test.ts
+++ b/packages/pi-plugin/src/commands/ctx-wrapup.test.ts
@@ -1,6 +1,8 @@
 /// <reference types="bun-types" />
 
 import { describe, expect, it, mock } from "bun:test";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
 	acquireCompartmentLease,
 	releaseCompartmentLease,
@@ -34,6 +36,14 @@ import {
 
 function createDb(): Database {
 	const db = new Database(":memory:");
+	initializeDatabase(db);
+	runMigrations(db);
+	return db;
+}
+
+function createFileDb(name: string): Database {
+	const path = join(tmpdir(), `${name}-${crypto.randomUUID()}.db`);
+	const db = new Database(path);
 	initializeDatabase(db);
 	runMigrations(db);
 	return db;
@@ -271,6 +281,54 @@ describe("Pi /ctx-wrapup", () => {
 			expect(runPiHistorianForWrapup).not.toHaveBeenCalled();
 			expect(getWrapupInProgressState(db, sessionId)).toBeNull();
 			releaseCompartmentLease(db, sessionId, foreignHolder);
+		} finally {
+			closeQuietly(db);
+		}
+	});
+
+	it("survives a busy-database lease release failure without rejecting", async () => {
+		// Cross-connection lock contention requires a shared file; two :memory:
+		// databases never contend. Mirrors the production shape: a second
+		// connection (omp session, dreamer, FTS indexer) holds BEGIN IMMEDIATE
+		// past busy_timeout while wrapup releases its compartment lease.
+		const db = createFileDb("pi-wrapup-busy-release");
+		try {
+			const sessionId = "pi-wrapup-busy-release";
+			const runPiHistorianForWrapup = mock(async (args) => {
+				const start = getLastCompartmentEndMessage(db, sessionId) + 1;
+				const end = Math.min(
+					args.boundarySnapshot.eligibleEndOrdinal - 1,
+					start + 2,
+				);
+				appendRange(db, sessionId, start, end);
+				args.onPublished?.();
+				// Simulate the production contention window: another process holds
+				// the writer lock past busy_timeout while wrapup releases its lease.
+				const blocker = new Database(db.filename);
+				blocker.exec("PRAGMA busy_timeout=1; BEGIN IMMEDIATE;");
+				try {
+					// Shrink the release connection's busy wait so the expected
+					// SQLITE_BUSY lands well inside bun's 5s default test timeout
+					// (initializeDatabase sets 5000ms; plain `bun test` in CI has
+					// no override — project constraint #5917).
+					db.exec("PRAGMA busy_timeout=250");
+					releaseCompartmentLease(db, sessionId, "stale-holder");
+				} finally {
+					blocker.exec("ROLLBACK");
+					blocker.close();
+				}
+			});
+
+			const result = await runPiWrapup(
+				pi().api,
+				deps(db, { runPiHistorianForWrapup }),
+				ctx(sessionId, 8),
+				sessionId,
+				2,
+			);
+
+			expect(result).toContain("## Magic Wrapup");
+			expect(getWrapupInProgressState(db, sessionId)).toBeNull();
 		} finally {
 			closeQuietly(db);
 		}

--- a/packages/pi-plugin/src/commands/ctx-wrapup.ts
+++ b/packages/pi-plugin/src/commands/ctx-wrapup.ts
@@ -398,6 +398,7 @@ export async function runPiWrapup(
 						);
 					}
 				}, COMPARTMENT_LEASE_RENEWAL_MS);
+				let chunkFailure: string | null = null;
 				try {
 					const runHistorian = deps.runPiHistorianForWrapup ?? runPiHistorian;
 					await runHistorian({
@@ -451,11 +452,28 @@ export async function runPiWrapup(
 							signalPiDeferredMaterialization(sessionId);
 						},
 					});
+				} catch (err) {
+					// Parity with OpenCode: runCompartmentAgent carries its own .catch,
+					// so its wrapup finally only sees settled promises. Pi lacks that
+					// inner layer; record the failure instead of letting a busy-starved
+					// release (or any historian throw) escape the command handler.
+					chunkFailure = err instanceof Error ? err.message : String(err);
 				} finally {
 					clearInterval(leaseRenewal);
-					releaseCompartmentLease(deps.db, sessionId, leaseHolder);
+					try {
+						releaseCompartmentLease(deps.db, sessionId, leaseHolder);
+					} catch (err) {
+						// Best-effort teardown: the lease row expires via its own TTL.
+						console.warn(
+							`[magic-context][pi] /ctx-wrapup compartment lease release failed for ${sessionId} (expires via TTL): ${err instanceof Error ? err.message : String(err)}`,
+						);
+					}
 				}
 
+				if (chunkFailure) {
+					failure = `historian chunk failed (${chunkFailure}); wrapped up through message ${lastEnd}. Run /ctx-wrapup again to continue.`;
+					break;
+				}
 				const afterEnd = getLastCompartmentEndMessage(deps.db, sessionId);
 				if (afterEnd <= lastEnd) {
 					failure = `No forward progress after chunk ${chunkIndex}; wrapped up through message ${lastEnd}. Run /ctx-wrapup again to continue.`;

--- a/packages/pi-plugin/src/context-handler.ts
+++ b/packages/pi-plugin/src/context-handler.ts
@@ -3640,7 +3640,15 @@ function spawnPiHistorianRun(args: {
 			// Close the cross-process check/lease race: /ctx-wrapup may have published
 			// its marker after the first check but before this process won the lease.
 			sessionLog(sessionId, "historian skipped: /ctx-wrapup became active");
-			releaseCompartmentLease(db, sessionId, holderId);
+			try {
+				releaseCompartmentLease(db, sessionId, holderId);
+			} catch (err) {
+				// Same best-effort contract as the finally-block release below.
+				sessionLog(
+					sessionId,
+					`historian lease release failed (expires via TTL): ${err instanceof Error ? err.message : String(err)}`,
+				);
+			}
 			return;
 		}
 		const renewal = startPiCompartmentLeaseRenewal(db, sessionId, holderId);
@@ -3726,15 +3734,32 @@ function spawnPiHistorianRun(args: {
 			});
 		} finally {
 			clearInterval(renewal);
-			releaseCompartmentLease(db, sessionId, holderId);
+			try {
+				releaseCompartmentLease(db, sessionId, holderId);
+			} catch (err) {
+				// Best-effort teardown: the lease row expires via its own TTL, so a
+				// busy_timeout-starved DELETE must not escape and reject this promise.
+				sessionLog(
+					sessionId,
+					`historian lease release failed (expires via TTL): ${err instanceof Error ? err.message : String(err)}`,
+				);
+			}
 		}
-	})().finally(() => {
-		inFlightHistorian.delete(sessionId);
-		unregister();
-		if (isContextHandlerSessionActive(sessionId)) {
-			historian.onStatusChange?.(ctx, sessionId);
-		}
-	});
+	})()
+		.catch((err) => {
+			// Parity with OpenCode's startCompartmentAgent .catch: the historian run
+			// promise is parked in inFlightHistorian for emergency/shutdown awaits,
+			// so an unhandled rejection here crashes the host via
+			// processTicksAndRejections instead of surfacing as a session log.
+			sessionLog(sessionId, "historian run failed:", err);
+		})
+		.finally(() => {
+			inFlightHistorian.delete(sessionId);
+			unregister();
+			if (isContextHandlerSessionActive(sessionId)) {
+				historian.onStatusChange?.(ctx, sessionId);
+			}
+		});
 	inFlightHistorian.set(sessionId, runPromise);
 	historian.onStatusChange?.(ctx, sessionId);
 }


### PR DESCRIPTION
The Pi historian run promise is parked in inFlightHistorian with no catch, so a SQLITE_BUSY from the finally-block lease release escaped as an unhandled rejection via processTicksAndRejections. OpenCode's startCompartmentAgent carries its own .catch; the Pi port dropped it.

- spawnPiHistorianRun: add .catch (session log) and guard both lease releases as best-effort teardown; the row expires via its 5-min TTL.
- runPiWrapup: catch historian chunk failures and surface them as a Partial result instead of letting them escape the command handler, and guard the per-chunk lease release the same way.
- Add a regression test that holds BEGIN IMMEDIATE on a second connection (shared file, not :memory:) and asserts wrapup survives the busy-starved release.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/magic-context/pr/412"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790987262&installation_model_id=22398&pr_number=412&repository=cortexkit%2Fmagic-context&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Fmagic-context%2Fpull%2F412&signature=34ae1795ed8f0f7dab5bbab624157ce36b5dcbc2cabfbbe10c1af90c435cb3d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Previously, Pi historian failures and busy-starved lease releases could escape as unhandled rejections and abort `/ctx-wrapup`. Now historian errors are logged, wrapup returns a Partial result, and failed lease deletes expire through their five-minute TTL instead.

**Bug Fixes**

- Failed historian chunks report the last completed message so a later `/ctx-wrapup` can continue.
- Adds a file-backed SQLite lock-contention regression test for lease release.

<sup>Written for commit 710b343aff25c8311fc07e5e2a777cf87a4a4c65. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/magic-context/pull/412?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR contains Pi historian failures so lease-release contention cannot escape as an unhandled rejection, and converts wrapup historian exceptions into partial results.
- Guards background and wrapup lease releases as best-effort teardown.
- Logs otherwise escaping background historian failures before in-flight cleanup.
- Adds a file-backed SQLite contention regression test for wrapup.
</details>


<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with non-blocking cleanup and error-sentinel issues worth correcting.

Failure containment remains intact, but an empty exception message can bypass the intended partial-failure branch, and the new regression test leaks its file-backed SQLite database.

**Files Needing Attention:** packages/pi-plugin/src/commands/ctx-wrapup.ts; packages/pi-plugin/src/commands/ctx-wrapup.test.ts

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/pi-plugin/src/commands/ctx-wrapup.ts | Converts historian exceptions into partial wrapup results and guards lease teardown, but its truthiness-based failure sentinel mishandles empty error messages. |
| packages/pi-plugin/src/context-handler.ts | Contains background historian and lease-release rejections while retaining in-flight cleanup and status notification. |
| packages/pi-plugin/src/commands/ctx-wrapup.test.ts | Adds realistic cross-connection SQLite contention coverage but leaves the generated temporary database file behind. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(pi): contain historian failures and ..."](https://github.com/cortexkit/magic-context/commit/710b343aff25c8311fc07e5e2a777cf87a4a4c65) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59766095)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Knowledge Base — [Pi plugin runtime](https://app.greptile.com/cortexkit/-/custom-context/knowledge-base/cortexkit/magic-context/-/docs/pi-plugin.md)

<!-- /greptile_comment -->