### PR TITLE
fix(pi-plugin): resolve the OMP host CLI via bin.omp — @oh-my-pi/pi-coding-agent declares no bin.pi

### DIFF
--- a/packages/pi-plugin/src/subagent-runner.test.ts
+++ b/packages/pi-plugin/src/subagent-runner.test.ts
@@ -213,28 +213,36 @@ function nextTick() {
 	return new Promise((resolve) => setTimeout(resolve, 0));
 }
 
-function writePiCliFixture(bin: string, useBinShim = false) {
+function writePiCliFixture(
+	bin: string,
+	useBinShim = false,
+	variant: "pi" | "omp" = "pi",
+) {
 	const root = mkdtempSync(join(tmpdir(), "mc-pi-cli-layout-"));
+	const packageName =
+		variant === "omp"
+			? "@oh-my-pi/pi-coding-agent"
+			: "@earendil-works/pi-coding-agent";
 	const packageRoot = join(
 		root,
 		"node_modules",
-		"@earendil-works",
-		"pi-coding-agent",
+		...packageName.split("/"),
 	);
 	const cliPath = join(packageRoot, bin);
 	mkdirSync(packageRoot, { recursive: true });
 	mkdirSync(dirname(cliPath), { recursive: true });
 	writeFileSync(
 		join(packageRoot, "package.json"),
-		JSON.stringify({
-			name: "@earendil-works/pi-coding-agent",
-			bin: { pi: bin },
-		}),
+		JSON.stringify(
+			variant === "omp"
+				? { name: packageName, bin: { omp: bin } }
+				: { name: packageName, bin: { pi: bin } },
+		),
 	);
 	writeFileSync(cliPath, "#!/usr/bin/env node\n");
 	if (!useBinShim) return { root, packageRoot, cliPath, entry: cliPath };
 
-	const shim = join(root, "bin", "pi");
+	const shim = join(root, "bin", variant);
 	mkdirSync(dirname(shim), { recursive: true });
 	symlinkSync(cliPath, shim);
 	return { root, packageRoot, cliPath, entry: shim };
@@ -311,6 +319,25 @@ describe("subagent-runner pure helpers", () => {
 			rmSync(fixture.root, { recursive: true, force: true });
 		}
 	});
+
+	it("resolves the OMP host CLI via bin.omp (@oh-my-pi/pi-coding-agent declares no bin.pi)", () => {
+		const fixture = writePiCliFixture("dist/cli.js", false, "omp");
+		try {
+			const invocation = __test.resolvePiInvocation({
+				execPath: "/runtime/node.exe",
+				argv1: fixture.entry,
+				platform: "win32",
+				resolvePackageJson: () => null,
+			});
+			expect(invocation).toEqual({
+				command: "/runtime/node.exe",
+				prefixArgs: [realpathSync(fixture.cliPath)],
+			});
+		} finally {
+			rmSync(fixture.root, { recursive: true, force: true });
+		}
+	});
+
 
 	it("resolves a bin-shim symlink to the package-declared Pi CLI", () => {
 		const fixture = writePiCliFixture("dist/bundle/cli.js", true);

--- a/packages/pi-plugin/src/subagent-runner.ts
+++ b/packages/pi-plugin/src/subagent-runner.ts
@@ -162,23 +162,17 @@ function resolvePiBin(
 	const binKeys = ["pi", "omp"];
 	let binEntry: string | undefined;
 	for (const key of binKeys) {
-		if (
-			typeof bin === "string" && key === "pi"
-		) {
+		if (typeof bin === "string" && key === "pi") {
 			binEntry = bin;
 			break;
 		}
-		if (
-			bin &&
-			typeof bin === "object" &&
-			typeof (bin as Record<string, unknown>)[key] === "string"
-		) {
-			binEntry = (bin as Record<string, string>)[key];
+		const objectBin = bin && typeof bin === "object" ? (bin as Record<string, unknown>) : undefined;
+		if (objectBin && typeof objectBin[key] === "string") {
+			binEntry = objectBin[key] as string;
 			break;
 		}
 	}
 	if (!binEntry) return null;
-
 
 	const packageRoot = resolvePath(found.dir);
 	const candidate = resolvePath(packageRoot, binEntry);

--- a/packages/pi-plugin/src/subagent-runner.ts
+++ b/packages/pi-plugin/src/subagent-runner.ts
@@ -147,7 +147,9 @@ function pathIsInside(root: string, candidate: string): boolean {
 }
 
 /**
- * Resolve the package's declared `pi` bin rather than assuming a dist layout.
+ * Resolve the package's declared CLI bin rather than assuming a dist layout.
+ * Pi declares `bin.pi`; OMP declares `bin.omp` (same package family —
+ * `@oh-my-pi/pi-coding-agent` is in the allowlist above but ships no `pi` bin).
  * Keep the containment guard: a package manifest may select only a
  * file below its own root, including after symlinks are canonicalized.
  */
@@ -157,15 +159,26 @@ function resolvePiBin(
 	checkedPaths: string[],
 ): string | null {
 	const bin = found.manifest.bin;
-	const binEntry =
-		typeof bin === "string"
-			? bin
-			: bin &&
-					typeof bin === "object" &&
-					typeof (bin as Record<string, unknown>).pi === "string"
-				? (bin as Record<string, string>).pi
-				: undefined;
+	const binKeys = ["pi", "omp"];
+	let binEntry: string | undefined;
+	for (const key of binKeys) {
+		if (
+			typeof bin === "string" && key === "pi"
+		) {
+			binEntry = bin;
+			break;
+		}
+		if (
+			bin &&
+			typeof bin === "object" &&
+			typeof (bin as Record<string, unknown>)[key] === "string"
+		) {
+			binEntry = (bin as Record<string, string>)[key];
+			break;
+		}
+	}
 	if (!binEntry) return null;
+
 
 	const packageRoot = resolvePath(found.dir);
 	const candidate = resolvePath(packageRoot, binEntry);


### PR DESCRIPTION
## Problem

On OMP (oh-my-pi) hosts without a standalone `pi` install, every Magic Context subagent — historian, dreamer, recomp, wrapup, upgrade, sidekick — fails at spawn:

```
│ ⚠ subagent run failed (spawn_failed): Executable not found in $PATH: "pi"
```

This surfaced as `/ctx-status` reporting `spawn_failed` and the historian never running (context compaction silently dead) after the user removed Pi.

## Root cause

`resolvePiInvocation` **positively identifies** the OMP host: it walks up from `process.argv[1]` and matches package names in `PI_CODING_AGENT_PACKAGE_NAMES`, which includes `@oh-my-pi/pi-coding-agent` (`subagent-runner.ts:44-47`). But `resolvePiBin` then only accepts `bin.pi`:

```ts
typeof (bin as Record<string, unknown>).pi === "string"
    ? (bin as Record<string, string>).pi
    : undefined;
```

OMP's package manifest declares `bin: { omp: "dist/cli.js" }` — there is no `bin.pi` — so resolution returns `null` for a package the resolver just positively identified. The fallback cascade then misses item by item (generic `bun.exe` runtime → skip; no bundled `@earendil-works/pi-coding-agent` peer → skip; no `pi`/`pi.cmd` on PATH → miss) and the final fallback spawns bare `"pi"`.

Verified against a real OMP 18.1.4 install: `@oh-my-pi/pi-coding-agent/package.json` → `"bin": {"omp": "dist/cli.js"}`.

## Fix

`resolvePiBin` accepts the `omp` bin key after `pi`. Pi hosts (manifests with `bin.pi`) resolve identically; OMP hosts now resolve `execPath + [realpath(dist/cli.js)]` — the same "re-invoke the exact host CLI" strategy the resolver already prefers, and cross-platform-safe per the existing design notes (no shell, containment guard, realpath canonicalization all unchanged).

## Verification

- With a fixture mirroring OMP's real layout (`@oh-my-pi/pi-coding-agent`, `bin: {omp: "dist/cli.js"}`), the patched `resolvePiInvocation` returns `{command: <bun>, prefixArgs: [<realpath>/dist/cli.js]}` and the old code returned the bare-`pi` fallback.
- The resolved invocation smoke-runs: `bun <OMP>/dist/cli.js --version` → `omp/18.1.4`, exit 0.
- Full `packages/pi-plugin` suite (915 tests): failure set byte-identical before and after the change (23 pre-existing environment-specific failures on Windows — symlink-creation EPERM in test fixtures and host-PATH leakage — reproduced on pristine `master` and on the `v0.41.1` tag; the change introduces no new failures).
- `tsc --noEmit` clean.

## Notes

- The same one-line predicate exists in the bundled `dist/` output; a patch release is sufficient for users (no manifest/config changes required).
- Reproduction context: Windows 11, OMP 18.1.4, MC 0.41.2 (`@cortexkit/pi-magic-context`), Pi not installed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/magic-context/pr/413"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790990114&installation_model_id=22398&pr_number=413&repository=cortexkit%2Fmagic-context&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Fmagic-context%2Fpull%2F413&signature=f415a968a3dae0ac2e24dbcd1c2942e6010e86f0dcf15d09dc9508ac860e281c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Magic Context subagent spawn failures on OMP hosts without a standalone `pi` install. `resolvePiBin` now uses OMP’s `bin.omp` entry instead of falling back to bare `pi`; hosts declaring `bin.pi` behave unchanged.

- Adds regression coverage for `@oh-my-pi/pi-coding-agent`, which declares only `bin.omp`.
- Preserves realpath canonicalization, package-root containment, and fallback ordering; no manifest or config changes are required.

<sup>Written for commit 31b70024ba67ed0964749d14ce1673c444901a67. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/magic-context/pull/413?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR fixes hidden child-agent startup on OMP-only installations by resolving the host CLI from `bin.omp` while retaining `bin.pi` precedence and existing path-containment checks.
- Extends package CLI resolution to recognize OMP’s declared executable.
- Adds an OMP-specific package fixture and regression assertion for the resolved invocation.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/pi-plugin/src/subagent-runner.ts | Adds `bin.omp` as the fallback package-declared CLI after `bin.pi`, preserving existing canonicalization and containment validation. |
| packages/pi-plugin/src/subagent-runner.test.ts | Adds an OMP-only package fixture and verifies that the resolver invokes its canonical `dist/cli.js` path through the current runtime. |

</details>

<sub>Reviews (2): Last reviewed commit: ["test(pi-plugin): cover the bin.omp OMP-h..."](https://github.com/cortexkit/magic-context/commit/31b70024ba67ed0964749d14ce1673c444901a67) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59784090)</sub>

**Context used:**

- Knowledge Base — [Pi plugin runtime](https://app.greptile.com/cortexkit/-/custom-context/knowledge-base/cortexkit/magic-context/-/docs/pi-plugin.md)

<!-- /greptile_comment -->