### PR TITLE
fix(ctx_memory): honor category in update

### DIFF
--- a/crates/mc-module/src/memory_render.rs
+++ b/crates/mc-module/src/memory_render.rs
@@ -15,7 +15,9 @@
 //! is the slice-4d integration decision, already ruled; the byte render here is pure.
 
 use crate::decay_render::{render_decayed_compartments, DecayRenderCompartment};
-use mc_store::{StoredMemory, StoredMemoryMutation, WorkspaceMembership};
+use mc_store::{
+    StoredMemory, StoredMemoryMutation, WorkspaceMembership, MEMORY_VISIBILITY_MUTATION_CATEGORY,
+};
 use std::cmp::Ordering;
 use std::collections::HashSet;
 
@@ -327,7 +329,10 @@ pub fn render_memory_updates(
         match m.mutation_type.as_str() {
             "update" => {
                 let category_attr = match &m.category {
-                    Some(category) if category != "__mc_visibility__" && !category.is_empty() => {
+                    Some(category)
+                        if category != MEMORY_VISIBILITY_MUTATION_CATEGORY
+                            && !category.is_empty() =>
+                    {
                         format!(" category=\"{}\"", escape_xml_attr(category))
                     }
                     _ => String::new(),

--- a/crates/mc-module/src/memory_render.rs
+++ b/crates/mc-module/src/memory_render.rs
@@ -325,11 +325,20 @@ pub fn render_memory_updates(
         vec!["These memories changed since the snapshot below — trust these:".to_string()];
     for m in mutations {
         match m.mutation_type.as_str() {
-            "update" => lines.push(format!(
-                "  <updated id=\"{}\">{}</updated>",
-                m.target_memory_id,
-                escape_xml_content(m.new_content.as_deref().unwrap_or(""))
-            )),
+            "update" => {
+                let category_attr = match &m.category {
+                    Some(category) if category != "__mc_visibility__" && !category.is_empty() => {
+                        format!(" category=\"{}\"", escape_xml_attr(category))
+                    }
+                    _ => String::new(),
+                };
+                lines.push(format!(
+                    "  <updated id=\"{}\"{}>{}</updated>",
+                    m.target_memory_id,
+                    category_attr,
+                    escape_xml_content(m.new_content.as_deref().unwrap_or(""))
+                ));
+            }
             "superseded" => match m.superseded_by_id {
                 Some(by) if resolvable_ids.contains(&by) => lines.push(format!(
                     "  <superseded id=\"{}\" by=\"{by}\"/>",

--- a/crates/mc-module/testdata/memory-update-delta-parity.json
+++ b/crates/mc-module/testdata/memory-update-delta-parity.json
@@ -1,5 +1,5 @@
 {
-  "first_delta": "<memory-updates>\nThese memories changed since the snapshot below — trust these:\n  <updated id=\"1\">updated &lt;alpha&gt; &amp; stable</updated>\n  <removed id=\"2\"/>\n</memory-updates>",
-  "second_delta": "<memory-updates>\nThese memories changed since the snapshot below — trust these:\n  <updated id=\"1\">updated &lt;alpha&gt; &amp; stable</updated>\n  <removed id=\"2\"/>\n  <superseded id=\"3\" by=\"4\"/>\n  <updated id=\"4\">merged &lt;delta&gt; &amp; sources</updated>\n</memory-updates>",
+  "first_delta": "<memory-updates>\nThese memories changed since the snapshot below — trust these:\n  <updated id=\"1\" category=\"CONSTRAINTS\">updated &lt;alpha&gt; &amp; stable</updated>\n  <removed id=\"2\"/>\n</memory-updates>",
+  "second_delta": "<memory-updates>\nThese memories changed since the snapshot below — trust these:\n  <updated id=\"1\" category=\"CONSTRAINTS\">updated &lt;alpha&gt; &amp; stable</updated>\n  <removed id=\"2\"/>\n  <superseded id=\"3\" by=\"4\"/>\n  <updated id=\"4\" category=\"CONSTRAINTS\">merged &lt;delta&gt; &amp; sources</updated>\n</memory-updates>",
   "reconciled_m0": "<project-memory>\n<CONSTRAINTS>\n#1: updated &lt;alpha&gt; &amp; stable\n#4: merged &lt;delta&gt; &amp; sources\n</CONSTRAINTS>\n</project-memory>"
 }

--- a/docs/specs/prompt-surface/budget-fixture.json
+++ b/docs/specs/prompt-surface/budget-fixture.json
@@ -58,11 +58,11 @@
       "ctx_reduce": { "chars": 91, "tokens": 31 },
       "ctx_expand": { "chars": 791, "tokens": 177 },
       "ctx_note": { "chars": 1574, "tokens": 378 },
-      "ctx_memory": { "chars": 840, "tokens": 201 },
+      "ctx_memory": { "chars": 912, "tokens": 216 },
       "ctx_search": { "chars": 777, "tokens": 184 },
-      "totalTokens": 971
+      "totalTokens": 986
     },
-    "builtInProviderVisibleTotal": 4720
+    "builtInProviderVisibleTotal": 4735
   },
   "mutableProseBaseline": 3749,
   "integerLightCeiling": 1825,

--- a/packages/pi-plugin/src/inject-compartments-pi.ts
+++ b/packages/pi-plugin/src/inject-compartments-pi.ts
@@ -37,6 +37,7 @@ import { isNoContentCompartment } from "@magic-context/core/features/magic-conte
 import {
 	type ContextDatabase,
 	clearCachedM0M1,
+	escapeXmlAttr,
 	escapeXmlContent,
 	GLOBAL_USER_PROFILE_PROJECT_PATH,
 	getCompartments,
@@ -1892,8 +1893,12 @@ function renderMemoryUpdatesBlockPi(args: {
 		}
 		if (mutation.visibilityChanged && mutation.newContent === null) continue;
 		if (mutation.mutationType === "update") {
+			const categoryAttr =
+				mutation.category && mutation.category !== "__mc_visibility__"
+					? ` category="${escapeXmlAttr(mutation.category)}"`
+					: "";
 			lines.push(
-				`  <updated id="${mutation.targetMemoryId}">${escapeXmlContent(mutation.newContent ?? "")}</updated>`,
+				`  <updated id="${mutation.targetMemoryId}"${categoryAttr}>${escapeXmlContent(mutation.newContent ?? "")}</updated>`,
 			);
 			continue;
 		}

--- a/packages/plugin/src/features/magic-context/storage-memory-mutation-log.ts
+++ b/packages/plugin/src/features/magic-context/storage-memory-mutation-log.ts
@@ -3,7 +3,7 @@ import type { Database } from "../../shared/sqlite";
 export type MemoryMutationType = "archive" | "delete" | "update" | "superseded";
 
 const MEMORY_MUTATION_TYPES = new Set<string>(["archive", "delete", "update", "superseded"]);
-const MEMORY_VISIBILITY_MUTATION_CATEGORY = "__mc_visibility__";
+export const MEMORY_VISIBILITY_MUTATION_CATEGORY = "__mc_visibility__";
 const MAX_MEMORY_REPLACEMENT_DEPTH = 8;
 
 // Terminal mutations mean the memory LEFT the active set (renders as

--- a/packages/plugin/src/features/magic-context/storage.ts
+++ b/packages/plugin/src/features/magic-context/storage.ts
@@ -113,6 +113,7 @@ export {
     getMemoryMutation,
     getMemoryMutationsForRender,
     getMemoryMutationsForRenderByProjects,
+    MEMORY_VISIBILITY_MUTATION_CATEGORY,
     type MemoryMutationLogRow,
     type MemoryMutationType,
     queueMemoryMutation,

--- a/packages/plugin/src/hooks/magic-context/inject-compartments.test.ts
+++ b/packages/plugin/src/hooks/magic-context/inject-compartments.test.ts
@@ -3157,6 +3157,55 @@ describe("m[0]/m[1] materialization", () => {
         expect(renderedText(bust[1])).not.toContain("Updated but not resident.");
     });
 
+    it("renders the recategorize category on <updated> in memory-updates", () => {
+        db = makeDb();
+        const projectDirectory = makeProjectDir();
+        const memory = insertMemory(db, {
+            projectPath: PROJECT_PATH,
+            category: "CONFIG_VALUES",
+            content: "old category fact",
+        });
+        const state = readStateFromMeta();
+        const hard = materializeM0({
+            db,
+            sessionId: SESSION_ID,
+            state,
+            projectPath: PROJECT_PATH,
+            projectDirectory,
+            injectDocs: false,
+            memoryInjectionBudgetTokens: 8_000,
+        });
+        expect(hard.renderedMemoryIds).toEqual([memory.id]);
+
+        db.prepare(
+            "UPDATE memories SET content = ?, category = ?, normalized_hash = ?, updated_at = ? WHERE id = ?",
+        ).run("new category fact", "CONSTRAINTS", "new-category-fact", Date.now(), memory.id);
+        queueMemoryMutation(db, {
+            projectPath: PROJECT_PATH,
+            mutationType: "update",
+            targetMemoryId: memory.id,
+            category: "CONSTRAINTS",
+            newContent: "new category fact",
+            queuedAt: 10,
+        });
+
+        const m1 = renderM1(
+            {
+                db,
+                sessionId: SESSION_ID,
+                state,
+                projectPath: PROJECT_PATH,
+                memoryInjectionBudgetTokens: 8_000,
+            },
+            hard.snapshotMarkers,
+            hard.renderedMemoryIds,
+        );
+        const updates = m1.match(/<memory-updates>[\s\S]*?<\/memory-updates>/)?.[0];
+        expect(updates).toContain(
+            `<updated id="${memory.id}" category="CONSTRAINTS">new category fact</updated>`,
+        );
+    });
+
     it("reconcile rematerialization advances the memory mutation cursor and omits memory-updates", () => {
         db = makeDb();
         const projectDirectory = makeProjectDir();

--- a/packages/plugin/src/hooks/magic-context/inject-compartments.ts
+++ b/packages/plugin/src/hooks/magic-context/inject-compartments.ts
@@ -2570,8 +2570,12 @@ function renderMemoryUpdatesBlock(args: {
         }
         if (mutation.visibilityChanged && mutation.newContent === null) continue;
         if (mutation.mutationType === "update") {
+            const categoryAttr =
+                mutation.category && mutation.category !== "__mc_visibility__"
+                    ? ` category="${escapeXmlAttr(mutation.category)}"`
+                    : "";
             lines.push(
-                `  <updated id="${mutation.targetMemoryId}">${escapeXmlContent(mutation.newContent ?? "")}</updated>`,
+                `  <updated id="${mutation.targetMemoryId}"${categoryAttr}>${escapeXmlContent(mutation.newContent ?? "")}</updated>`,
             );
             continue;
         }

--- a/packages/plugin/src/hooks/magic-context/inject-compartments.ts
+++ b/packages/plugin/src/hooks/magic-context/inject-compartments.ts
@@ -21,6 +21,7 @@ import type { MuralWireOptions } from "../../features/magic-context/mural/resolv
 import { isNoContentCompartment } from "../../features/magic-context/no-content-compartment";
 import {
     GLOBAL_USER_PROFILE_PROJECT_PATH,
+    MEMORY_VISIBILITY_MUTATION_CATEGORY,
     getMaxM0MutationId,
     getMaxMemoryMutationId,
     getMaxMemoryMutationIdForProjects,
@@ -2571,7 +2572,7 @@ function renderMemoryUpdatesBlock(args: {
         if (mutation.visibilityChanged && mutation.newContent === null) continue;
         if (mutation.mutationType === "update") {
             const categoryAttr =
-                mutation.category && mutation.category !== "__mc_visibility__"
+                mutation.category && mutation.category !== MEMORY_VISIBILITY_MUTATION_CATEGORY
                     ? ` category="${escapeXmlAttr(mutation.category)}"`
                     : "";
             lines.push(

--- a/packages/plugin/src/shared/prompt-surface-a1-golden.md
+++ b/packages/plugin/src/shared/prompt-surface-a1-golden.md
@@ -336,7 +336,7 @@ Example: ctx_note(action="write", content="Re-run the perf benchmark once the bo
 }
 ```
 
-### ctx_memory — description ~234 tokens, params ~201 tokens (total ~435)
+### ctx_memory — description ~234 tokens, params ~216 tokens (total ~450)
 
 **Description:**
 

--- a/packages/plugin/src/shared/prompt-surface-a1-golden.md
+++ b/packages/plugin/src/shared/prompt-surface-a1-golden.md
@@ -376,7 +376,7 @@ Example: ctx_memory(action="write", category="CONSTRAINTS", content="Pi stores s
     "type": "string"
   },
   "category": {
-    "description": "What kind of fact this is (required for write; optional merge override)",
+    "description": "What kind of fact this is (required for write; optional on update to recategorize, omitted keeps the current category; optional merge override)",
     "type": "string",
     "enum": [
       "PROJECT_RULES",

--- a/packages/plugin/src/tools/ctx-memory/tools.test.ts
+++ b/packages/plugin/src/tools/ctx-memory/tools.test.ts
@@ -1983,6 +1983,129 @@ describe("createCtxMemoryTools", () => {
             }
         });
 
+        it("returns a friendly duplicate error when the constraint code is remapped but the message matches", async () => {
+            const originalPrepare = db.prepare.bind(db);
+            const originalExec = db.exec.bind(db);
+            let inTx = false;
+            (db as { exec: (sql: string) => unknown }).exec = (sql: string) => {
+                const text = String(sql);
+                if (/\bBEGIN\b/i.test(text)) inTx = true;
+                try {
+                    return originalExec(sql);
+                } catch (error) {
+                    inTx = false;
+                    throw error;
+                } finally {
+                    if (/\bCOMMIT\b/i.test(text) || /\bROLLBACK\b/i.test(text)) inTx = false;
+                }
+            };
+            (db as { prepare: (sql: string) => unknown }).prepare = (sql: string) => {
+                const stmt = originalPrepare(sql);
+                if (
+                    sql.includes(
+                        "FROM memories WHERE project_path = ? AND category = ? AND normalized_hash = ?",
+                    )
+                ) {
+                    const originalGet = stmt.get.bind(stmt);
+                    stmt.get = (...args: unknown[]) => (inTx ? undefined : originalGet(...args));
+                }
+                if (sql.includes("UPDATE memories SET content = ?")) {
+                    return {
+                        run: () => {
+                            const error = new Error(
+                                "UNIQUE constraint failed: memories.project_path, memories.category, memories.normalized_hash",
+                            ) as Error & { code?: string };
+                            error.code = "SQLITE_ERROR";
+                            throw error;
+                        },
+                    };
+                }
+                return stmt;
+            };
+
+            try {
+                const existing = insertMemory(db, {
+                    projectPath: "/repo/project",
+                    category: "CONSTRAINTS",
+                    content: "timeout=5s",
+                });
+                const memory = insertMemory(db, {
+                    projectPath: "/repo/project",
+                    category: "CONFIG_VALUES",
+                    content: "cache_ttl=5m",
+                });
+                const result = await tools.ctx_memory.execute(
+                    {
+                        action: "update",
+                        ids: [memory.id],
+                        category: "CONSTRAINTS",
+                        content: "timeout=5s",
+                    },
+                    toolContext("ses-primary", "general"),
+                );
+
+                expect(result).toBe(
+                    `Error: Memory content already exists as ID ${existing.id}; merge or archive duplicates instead.`,
+                );
+                expect(String(result)).not.toContain("UNIQUE constraint failed");
+                expect(getMemoryById(db, memory.id)).toMatchObject({
+                    category: "CONFIG_VALUES",
+                    content: "cache_ttl=5m",
+                });
+            } finally {
+                (db as { prepare: typeof originalPrepare }).prepare = originalPrepare;
+                (db as { exec: typeof originalExec }).exec = originalExec;
+            }
+        });
+
+        it("rethrows authority errors instead of treating them as duplicates", async () => {
+            const originalPrepare = db.prepare.bind(db);
+            const memory = insertMemory(db, {
+                projectPath: "/repo/project",
+                category: "CONFIG_VALUES",
+                content: "cache_ttl=5m",
+            });
+            (db as { prepare: (sql: string) => unknown }).prepare = (sql: string) => {
+                const stmt = originalPrepare(sql);
+                if (sql.includes("UPDATE memories SET content = ?")) {
+                    return {
+                        run: () => {
+                            const error = new Error("authority is draining") as Error & {
+                                code: string;
+                            };
+                            error.code = "authority_draining";
+                            throw error;
+                        },
+                    };
+                }
+                return stmt;
+            };
+
+            let thrown: unknown;
+            try {
+                await tools.ctx_memory.execute(
+                    {
+                        action: "update",
+                        ids: [memory.id],
+                        content: "cache_ttl=10m",
+                    },
+                    toolContext("ses-primary", "general"),
+                );
+            } catch (error) {
+                thrown = error;
+            } finally {
+                (db as { prepare: typeof originalPrepare }).prepare = originalPrepare;
+            }
+
+            expect(thrown).toBeInstanceOf(Error);
+            expect(String(thrown)).toContain("authority is draining");
+            expect(String(thrown)).not.toContain("already exists as ID");
+            expect(getMemoryById(db, memory.id)).toMatchObject({
+                category: "CONFIG_VALUES",
+                content: "cache_ttl=5m",
+            });
+        });
+
         it("rolls back content updates when queueing the mutation fails", async () => {
             const memory = insertMemory(db, {
                 projectPath: "/repo/project",

--- a/packages/plugin/src/tools/ctx-memory/tools.test.ts
+++ b/packages/plugin/src/tools/ctx-memory/tools.test.ts
@@ -1887,6 +1887,102 @@ describe("createCtxMemoryTools", () => {
             });
         });
 
+        it("rejects recategorizing onto an existing duplicate without throwing a constraint", async () => {
+            const existing = insertMemory(db, {
+                projectPath: "/repo/project",
+                category: "CONSTRAINTS",
+                content: "timeout=5s",
+            });
+            const memory = insertMemory(db, {
+                projectPath: "/repo/project",
+                category: "CONFIG_VALUES",
+                content: "timeout=5s",
+            });
+
+            const result = await tools.ctx_memory.execute(
+                {
+                    action: "update",
+                    ids: [memory.id],
+                    category: "CONSTRAINTS",
+                    content: "timeout=5s",
+                },
+                toolContext("ses-primary", "general"),
+            );
+
+            expect(result).toBe(
+                `Error: Memory content already exists as ID ${existing.id}; merge or archive duplicates instead.`,
+            );
+            expect(String(result)).not.toContain("UNIQUE constraint failed");
+            expect(getMemoryById(db, memory.id)).toMatchObject({
+                category: "CONFIG_VALUES",
+                content: "timeout=5s",
+            });
+        });
+
+        it("returns a friendly duplicate error after a unique-constraint fallback", async () => {
+            const originalPrepare = db.prepare.bind(db);
+            const originalExec = db.exec.bind(db);
+            let inTx = false;
+            (db as { exec: (sql: string) => unknown }).exec = (sql: string) => {
+                const text = String(sql);
+                if (/\bBEGIN\b/i.test(text)) inTx = true;
+                try {
+                    return originalExec(sql);
+                } catch (error) {
+                    inTx = false;
+                    throw error;
+                } finally {
+                    if (/\bCOMMIT\b/i.test(text) || /\bROLLBACK\b/i.test(text)) inTx = false;
+                }
+            };
+            (db as { prepare: (sql: string) => unknown }).prepare = (sql: string) => {
+                const stmt = originalPrepare(sql);
+                if (
+                    sql.includes(
+                        "FROM memories WHERE project_path = ? AND category = ? AND normalized_hash = ?",
+                    )
+                ) {
+                    const originalGet = stmt.get.bind(stmt);
+                    stmt.get = (...args: unknown[]) => (inTx ? undefined : originalGet(...args));
+                }
+                return stmt;
+            };
+
+            try {
+                const existing = insertMemory(db, {
+                    projectPath: "/repo/project",
+                    category: "CONSTRAINTS",
+                    content: "timeout=5s",
+                });
+                const memory = insertMemory(db, {
+                    projectPath: "/repo/project",
+                    category: "CONFIG_VALUES",
+                    content: "cache_ttl=5m",
+                });
+                const result = await tools.ctx_memory.execute(
+                    {
+                        action: "update",
+                        ids: [memory.id],
+                        category: "CONSTRAINTS",
+                        content: "timeout=5s",
+                    },
+                    toolContext("ses-primary", "general"),
+                );
+
+                expect(result).toBe(
+                    `Error: Memory content already exists as ID ${existing.id}; merge or archive duplicates instead.`,
+                );
+                expect(String(result)).not.toContain("UNIQUE constraint failed");
+                expect(getMemoryById(db, memory.id)).toMatchObject({
+                    category: "CONFIG_VALUES",
+                    content: "cache_ttl=5m",
+                });
+            } finally {
+                (db as { prepare: typeof originalPrepare }).prepare = originalPrepare;
+                (db as { exec: typeof originalExec }).exec = originalExec;
+            }
+        });
+
         it("rolls back content updates when queueing the mutation fails", async () => {
             const memory = insertMemory(db, {
                 projectPath: "/repo/project",

--- a/packages/plugin/src/tools/ctx-memory/tools.test.ts
+++ b/packages/plugin/src/tools/ctx-memory/tools.test.ts
@@ -1690,6 +1690,130 @@ describe("createCtxMemoryTools", () => {
             expect(getMemoryById(db, memory.id)?.status).toBe("archived");
         });
 
+        it("persists a valid category change on update", async () => {
+            const memory = insertMemory(db, {
+                projectPath: "/repo/project",
+                category: "CONFIG_VALUES",
+                content: "cache_ttl=5m",
+            });
+
+            const result = await tools.ctx_memory.execute(
+                {
+                    action: "update",
+                    ids: [memory.id],
+                    category: "CONSTRAINTS",
+                    content: "cache_ttl=10m",
+                },
+                toolContext("ses-primary", "general"),
+            );
+
+            expect(result).toBe(`Updated memory [ID: ${memory.id}] in CONSTRAINTS.`);
+            expect(getMemoryById(db, memory.id)).toMatchObject({
+                category: "CONSTRAINTS",
+                content: "cache_ttl=10m",
+            });
+            expect(getMutationRows(db, "/repo/project", [memory.id])).toMatchObject([
+                {
+                    mutationType: "update",
+                    targetMemoryId: memory.id,
+                    category: "CONSTRAINTS",
+                    newContent: "cache_ttl=10m",
+                },
+            ]);
+        });
+
+        it("keeps the current category when update omits category", async () => {
+            const memory = insertMemory(db, {
+                projectPath: "/repo/project",
+                category: "CONFIG_VALUES",
+                content: "cache_ttl=5m",
+            });
+
+            const result = await tools.ctx_memory.execute(
+                {
+                    action: "update",
+                    ids: [memory.id],
+                    content: "cache_ttl=10m",
+                },
+                toolContext("ses-primary", "general"),
+            );
+
+            expect(result).toBe(`Updated memory [ID: ${memory.id}] in CONFIG_VALUES.`);
+            expect(getMemoryById(db, memory.id)?.category).toBe("CONFIG_VALUES");
+            expect(getMutationRows(db, "/repo/project", [memory.id])).toMatchObject([
+                { mutationType: "update", category: "CONFIG_VALUES" },
+            ]);
+        });
+
+        it("keeps the current category when update receives an invalid category", async () => {
+            const memory = insertMemory(db, {
+                projectPath: "/repo/project",
+                category: "CONFIG_VALUES",
+                content: "cache_ttl=5m",
+            });
+
+            const result = await tools.ctx_memory.execute(
+                {
+                    action: "update",
+                    ids: [memory.id],
+                    category: "NOT_A_CATEGORY",
+                    content: "cache_ttl=10m",
+                },
+                toolContext("ses-primary", "general"),
+            );
+
+            expect(result).toBe(`Updated memory [ID: ${memory.id}] in CONFIG_VALUES.`);
+            expect(getMemoryById(db, memory.id)).toMatchObject({
+                category: "CONFIG_VALUES",
+                content: "cache_ttl=10m",
+            });
+            expect(getMutationRows(db, "/repo/project", [memory.id])).toMatchObject([
+                { mutationType: "update", category: "CONFIG_VALUES" },
+            ]);
+        });
+
+        it("still rewrites content when recategorizing or omitting category", async () => {
+            const recategorized = insertMemory(db, {
+                projectPath: "/repo/project",
+                category: "CONFIG_VALUES",
+                content: "old recategorize content",
+            });
+            const omitted = insertMemory(db, {
+                projectPath: "/repo/project",
+                category: "NAMING",
+                content: "old omitted-category content",
+            });
+
+            const recategorizeResult = await tools.ctx_memory.execute(
+                {
+                    action: "update",
+                    ids: [recategorized.id],
+                    category: "PROJECT_RULES",
+                    content: "new recategorize content",
+                },
+                toolContext("ses-primary", "general"),
+            );
+            const omitResult = await tools.ctx_memory.execute(
+                {
+                    action: "update",
+                    ids: [omitted.id],
+                    content: "new omitted-category content",
+                },
+                toolContext("ses-primary", "general"),
+            );
+
+            expect(recategorizeResult).toContain("in PROJECT_RULES");
+            expect(omitResult).toContain("in NAMING");
+            expect(getMemoryById(db, recategorized.id)).toMatchObject({
+                category: "PROJECT_RULES",
+                content: "new recategorize content",
+            });
+            expect(getMemoryById(db, omitted.id)).toMatchObject({
+                category: "NAMING",
+                content: "new omitted-category content",
+            });
+        });
+
         it("rolls back content updates when queueing the mutation fails", async () => {
             const memory = insertMemory(db, {
                 projectPath: "/repo/project",

--- a/packages/plugin/src/tools/ctx-memory/tools.test.ts
+++ b/packages/plugin/src/tools/ctx-memory/tools.test.ts
@@ -1690,6 +1690,79 @@ describe("createCtxMemoryTools", () => {
             expect(getMemoryById(db, memory.id)?.status).toBe("archived");
         });
 
+        it("rejects recategorizing a legacy raw-path memory onto an existing duplicate", async () => {
+            const rawProjectPath = "/legacy/raw-project";
+            const projectIdentity = normalizeStoredProjectPath(rawProjectPath);
+            const legacyTools = createCtxMemoryTools({
+                db,
+                resolveProjectPath: () => projectIdentity,
+                memoryEnabled: true,
+                embeddingEnabled: false,
+            });
+            const existing = insertMemory(db, {
+                projectPath: rawProjectPath,
+                category: "CONSTRAINTS",
+                content: "timeout=5s",
+            });
+            const memory = insertMemory(db, {
+                projectPath: rawProjectPath,
+                category: "CONFIG_DEFAULTS",
+                content: "timeout=5s",
+            });
+
+            const result = await legacyTools.ctx_memory.execute(
+                {
+                    action: "update",
+                    ids: [memory.id],
+                    category: "CONSTRAINTS",
+                    content: "timeout=5s",
+                },
+                toolContext("ses-primary", "general"),
+            );
+
+            expect(result).toBe(
+                `Error: Memory content already exists as ID ${existing.id}; merge or archive duplicates instead.`,
+            );
+            expect(getMemoryById(db, memory.id)).toMatchObject({
+                category: "CONFIG_DEFAULTS",
+                content: "timeout=5s",
+                projectPath: rawProjectPath,
+            });
+        });
+
+        it("recategorizes a legacy raw-path memory when no duplicate exists under the stored path", async () => {
+            const rawProjectPath = "/legacy/raw-project";
+            const projectIdentity = normalizeStoredProjectPath(rawProjectPath);
+            const legacyTools = createCtxMemoryTools({
+                db,
+                resolveProjectPath: () => projectIdentity,
+                memoryEnabled: true,
+                embeddingEnabled: false,
+            });
+            const memory = insertMemory(db, {
+                projectPath: rawProjectPath,
+                category: "CONFIG_DEFAULTS",
+                content: "timeout=5s",
+            });
+
+            const result = await legacyTools.ctx_memory.execute(
+                {
+                    action: "update",
+                    ids: [memory.id],
+                    category: "CONSTRAINTS",
+                    content: "timeout=5s",
+                },
+                toolContext("ses-primary", "general"),
+            );
+
+            expect(result).toBe(`Updated memory [ID: ${memory.id}] in CONSTRAINTS.`);
+            expect(getMemoryById(db, memory.id)).toMatchObject({
+                category: "CONSTRAINTS",
+                content: "timeout=5s",
+                projectPath: rawProjectPath,
+            });
+        });
+
         it("persists a valid category change on update", async () => {
             const memory = insertMemory(db, {
                 projectPath: "/repo/project",

--- a/packages/plugin/src/tools/ctx-memory/tools.ts
+++ b/packages/plugin/src/tools/ctx-memory/tools.ts
@@ -389,6 +389,20 @@ function inactiveMemoryError(id: number, action: "updating" | "merging" | "archi
     return `Error: Memory with ID ${id} is archived or superseded; restore it before ${action}.`;
 }
 
+function isUniqueConstraintError(error: unknown): boolean {
+    if (!(error instanceof Error)) {
+        return false;
+    }
+    const code = "code" in error ? (error as { code?: unknown }).code : undefined;
+    if (typeof code === "string" && code.startsWith("SQLITE_CONSTRAINT")) {
+        return true;
+    }
+    return error.message.includes("UNIQUE constraint failed");
+}
+
+const DUPLICATE_MEMORY_ERROR = (id: number): string =>
+    `Error: Memory content already exists as ID ${id}; merge or archive duplicates instead.`;
+
 function updateMemoryContentInCurrentTransaction(
     db: CtxMemoryToolDeps["db"],
     memory: Memory,
@@ -764,33 +778,55 @@ function createCtxMemoryTool(deps: CtxMemoryToolDeps): ToolDefinition {
                 // stored path, which UPDATE leaves unchanged (legacy raw paths
                 // stay raw). Lookup with that same identity so a recategorize
                 // collision returns the duplicate error instead of throwing.
-                const duplicate = getMemoryByHash(
-                    deps.db,
-                    rawProjectPath,
-                    targetCategory,
-                    normalizedHash,
-                );
-                if (duplicate && duplicate.id !== memory.id) {
-                    return `Error: Memory content already exists as ID ${duplicate.id}; merge or archive duplicates instead.`;
-                }
-
+                // Probe + write share one BEGIN IMMEDIATE so a concurrent insert
+                // cannot slip in between; UNIQUE remains the friendly fallback.
                 const projectIdentity = targetIdentityForStoredPath(rawProjectPath);
-                runImmediateTransaction(deps.db, () => {
-                    updateMemoryContentInCurrentTransaction(
-                        deps.db,
-                        memory,
-                        content,
-                        normalizedHash,
-                        targetCategory,
-                    );
-                    queueMemoryMutation(deps.db, {
-                        projectPath: projectIdentity,
-                        mutationType: "update",
-                        targetMemoryId: memory.id,
-                        category: targetCategory,
-                        newContent: content,
+                let duplicateId: number | null = null;
+                try {
+                    runImmediateTransaction(deps.db, () => {
+                        const duplicate = getMemoryByHash(
+                            deps.db,
+                            rawProjectPath,
+                            targetCategory,
+                            normalizedHash,
+                        );
+                        if (duplicate && duplicate.id !== memory.id) {
+                            duplicateId = duplicate.id;
+                            return;
+                        }
+                        updateMemoryContentInCurrentTransaction(
+                            deps.db,
+                            memory,
+                            content,
+                            normalizedHash,
+                            targetCategory,
+                        );
+                        queueMemoryMutation(deps.db, {
+                            projectPath: projectIdentity,
+                            mutationType: "update",
+                            targetMemoryId: memory.id,
+                            category: targetCategory,
+                            newContent: content,
+                        });
                     });
-                });
+                } catch (error) {
+                    if (!isUniqueConstraintError(error)) {
+                        throw error;
+                    }
+                    const raced = getMemoryByHash(
+                        deps.db,
+                        rawProjectPath,
+                        targetCategory,
+                        normalizedHash,
+                    );
+                    if (raced && raced.id !== memory.id) {
+                        return DUPLICATE_MEMORY_ERROR(raced.id);
+                    }
+                    throw error;
+                }
+                if (duplicateId !== null) {
+                    return DUPLICATE_MEMORY_ERROR(duplicateId);
+                }
                 queueMemoryEmbedding({
                     deps,
                     sessionId: toolContext.sessionID,

--- a/packages/plugin/src/tools/ctx-memory/tools.ts
+++ b/packages/plugin/src/tools/ctx-memory/tools.ts
@@ -760,9 +760,13 @@ function createCtxMemoryTool(deps: CtxMemoryToolDeps): ToolDefinition {
                     (V2_MEMORY_CATEGORIES as readonly string[]).includes(args.category)
                         ? (args.category as MemoryCategory)
                         : memory.category;
+                // UNIQUE(project_path, category, normalized_hash) is on the
+                // stored path, which UPDATE leaves unchanged (legacy raw paths
+                // stay raw). Lookup with that same identity so a recategorize
+                // collision returns the duplicate error instead of throwing.
                 const duplicate = getMemoryByHash(
                     deps.db,
-                    targetIdentityForStoredPath(rawProjectPath),
+                    rawProjectPath,
                     targetCategory,
                     normalizedHash,
                 );

--- a/packages/plugin/src/tools/ctx-memory/tools.ts
+++ b/packages/plugin/src/tools/ctx-memory/tools.ts
@@ -390,14 +390,11 @@ function inactiveMemoryError(id: number, action: "updating" | "merging" | "archi
 }
 
 function isUniqueConstraintError(error: unknown): boolean {
-    if (!(error instanceof Error)) {
-        return false;
-    }
-    const code = "code" in error ? (error as { code?: unknown }).code : undefined;
-    if (typeof code === "string" && code.startsWith("SQLITE_CONSTRAINT")) {
-        return true;
-    }
-    return error.message.includes("UNIQUE constraint failed");
+    return (
+        error instanceof Error &&
+        "code" in error &&
+        (error as { code?: unknown }).code === "SQLITE_CONSTRAINT_UNIQUE"
+    );
 }
 
 const DUPLICATE_MEMORY_ERROR = (id: number): string =>

--- a/packages/plugin/src/tools/ctx-memory/tools.ts
+++ b/packages/plugin/src/tools/ctx-memory/tools.ts
@@ -390,11 +390,16 @@ function inactiveMemoryError(id: number, action: "updating" | "merging" | "archi
 }
 
 function isUniqueConstraintError(error: unknown): boolean {
-    return (
-        error instanceof Error &&
-        "code" in error &&
-        (error as { code?: unknown }).code === "SQLITE_CONSTRAINT_UNIQUE"
-    );
+    if (!(error instanceof Error)) {
+        return false;
+    }
+    const code = "code" in error ? (error as { code?: unknown }).code : undefined;
+    if (code === "SQLITE_CONSTRAINT_UNIQUE") {
+        return true;
+    }
+    // bun:sqlite sets SQLITE_CONSTRAINT_UNIQUE; node:sqlite may omit or remap
+    // the code. sqlite3_errmsg text is stable across adapters.
+    return /UNIQUE constraint failed/i.test(error.message);
 }
 
 const DUPLICATE_MEMORY_ERROR = (id: number): string =>

--- a/packages/plugin/src/tools/ctx-memory/tools.ts
+++ b/packages/plugin/src/tools/ctx-memory/tools.ts
@@ -394,10 +394,11 @@ function updateMemoryContentInCurrentTransaction(
     memory: Memory,
     content: string,
     normalizedHash: string,
+    targetCategory: MemoryCategory = memory.category,
 ): void {
     db.prepare(
-        "UPDATE memories SET content = ?, normalized_hash = ?, updated_at = ? WHERE id = ?",
-    ).run(content, normalizedHash, Date.now(), memory.id);
+        "UPDATE memories SET content = ?, category = ?, normalized_hash = ?, updated_at = ? WHERE id = ?",
+    ).run(content, targetCategory, normalizedHash, Date.now(), memory.id);
     // The classify `shareable` verdict was scored against the OLD content; new
     // content invalidates it. Fail closed → private; the dreamer re-scores later.
     if (hasMemoryShareableColumn(db)) {
@@ -428,7 +429,9 @@ const ctxMemoryArgsShape = {
     category: tool.schema
         .enum([...V2_MEMORY_CATEGORIES])
         .optional()
-        .describe("What kind of fact this is (required for write; optional merge override)"),
+        .describe(
+            "What kind of fact this is (required for write; optional on update to recategorize, omitted keeps the current category; optional merge override)",
+        ),
     ids: tool.schema
         .array(tool.schema.number())
         .optional()
@@ -752,10 +755,15 @@ function createCtxMemoryTool(deps: CtxMemoryToolDeps): ToolDefinition {
                 }
 
                 const normalizedHash = computeNormalizedHash(content);
+                const targetCategory =
+                    args.category &&
+                    (V2_MEMORY_CATEGORIES as readonly string[]).includes(args.category)
+                        ? (args.category as MemoryCategory)
+                        : memory.category;
                 const duplicate = getMemoryByHash(
                     deps.db,
                     targetIdentityForStoredPath(rawProjectPath),
-                    memory.category,
+                    targetCategory,
                     normalizedHash,
                 );
                 if (duplicate && duplicate.id !== memory.id) {
@@ -769,12 +777,13 @@ function createCtxMemoryTool(deps: CtxMemoryToolDeps): ToolDefinition {
                         memory,
                         content,
                         normalizedHash,
+                        targetCategory,
                     );
                     queueMemoryMutation(deps.db, {
                         projectPath: projectIdentity,
                         mutationType: "update",
                         targetMemoryId: memory.id,
-                        category: memory.category,
+                        category: targetCategory,
                         newContent: content,
                     });
                 });
@@ -787,7 +796,7 @@ function createCtxMemoryTool(deps: CtxMemoryToolDeps): ToolDefinition {
                 });
                 requestRustMemorySync(deps, toolContext.sessionID);
 
-                return `Updated memory [ID: ${memory.id}] in ${memory.category}.`;
+                return `Updated memory [ID: ${memory.id}] in ${targetCategory}.`;
             }
 
             if (args.action === "merge") {


### PR DESCRIPTION
Fixes https://github.com/cortexkit/magic-context/issues/436

## Summary

`ctx_memory` `update` accepted `category` in the tool schema but never wrote it. The UPDATE statement only set `content` / `normalized_hash` / `updated_at`, and three follow-up sites still used the stored category.

**Root cause:** `updateMemoryContentInCurrentTransaction` never received a target category, so duplicate hashing, `queueMemoryMutation`, and the success echo all stayed on `memory.category`.

**Fix (TS path):**
- A valid v2 category (`PROJECT_RULES` / `ARCHITECTURE` / `CONSTRAINTS` / `CONFIG_VALUES` / `NAMING`) retargets the row.
- Omitted or invalid category keeps the current category (backward compatible).
- Duplicate check, mutation log, and `Updated memory [ID: …] in ${…}` all use the target category.
- Schema description now states that `update` may recategorize; omit to keep.

## Tests

Four new cases in `packages/plugin/src/tools/ctx-memory/tools.test.ts`:
- valid category persists
- omitted category keeps the current class
- invalid category falls back to the current class
- content rewrite still succeeds in both recategorize and omit paths

Local gates:
- `bun run typecheck` passed
- `bun run lint` passed (pre-existing pi-plugin warning only)
- `bun run build` passed
- `packages/plugin` `ctx-memory` suite: 76/76 passed

## Scope

TypeScript `packages/plugin` path only. When `authorityState === "MODULE"`, `update` still delegates to the private Rust module; that path is unchanged and should be followed up separately for parity.

Prompt-surface A1 golden and `docs/specs/prompt-surface/budget-fixture.json` were updated only because the category parameter description changed (serialized schema 840/201 → 912/216 tokens).

## Live validation

Against pi-magic-context 0.41.4 with the same semantics locally:
- valid category on `update` → persisted category changes
- omitted category → category unchanged
- invalid category → category unchanged
- content-only `update` → content rewritten

## Residual / Note

Local full `bun run test` (plugin `--parallel --timeout 30000`, same as CI `check-plugin`) twice hit two unrelated timeouts under parallel load:
- `AFT warm inventory sends only boundary-owned seeds with one raw batch` (~43s vs 7.8s alone)
- `createTransform > hydrates only dropped rows for visible-target replay with 98% active tags` (~37s vs 11.9s alone)

This change does not touch those tests. Isolated reruns passed. typecheck / lint / build and the ctx-memory 76/76 suite all passed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/cortexkit/codesmith/magic-context/pr/438"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791749086&installation_model_id=22398&pr_number=438&repository=cortexkit%2Fmagic-context&return_to=https%3A%2F%2Fgithub.com%2Fcortexkit%2Fmagic-context%2Fpull%2F438&signature=c64bbb12888956bc86f9dd545f8f74a7abed4e877dadfc62524e62bc3b5f9dfc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes `ctx_memory` `update` honor the `category` argument so a valid v2 category recategorizes the row, and surfaces that category in memory-updates deltas.

- Omitted or invalid category keeps the current one, so existing callers are unaffected.
- Duplicate detection runs inside the same transaction against the stored path; a unique-constraint race falls back to the friendly duplicate error across bun and node sqlite error shapes.
- `<updated>` elements carry a `category` attribute in the TypeScript, pi-plugin, and Rust renderers.
- The schema now says `update` may recategorize; omit `category` to keep the current one.
- Tests cover valid, omitted, invalid, content-only, legacy raw-path, and constraint-race recategorization paths.
- The Rust module's update execution still doesn't write the category; that parity follow-up remains.

<sup>Written for commit b8a86489130cb44debb1bbc11995ee04a4e3f23d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/cortexkit/magic-context/pull/438?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR makes TypeScript `ctx_memory update` persist valid category changes and consistently use the resulting category for duplicate detection, mutation logging, rendering, and the success response.
- Keeps the existing category when the argument is omitted or invalid.
- Performs duplicate detection against the row’s stored project path inside the update transaction.
- Converts supported SQLite uniqueness races into the established duplicate-memory response.
- Adds category attributes to update deltas across TypeScript, pi-plugin, and Rust renderers.
- Expands coverage for recategorization, legacy paths, rollback behavior, and adapter-specific constraint errors.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge; no actionable regression remains in the changes since the previous review.

The previously reported legacy-path duplicate failure and adapter-specific uniqueness fallback findings are resolved, and the latest fallback recognizes remapped or absent SQLite codes without swallowing unrelated current transaction errors.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/plugin/src/tools/ctx-memory/tools.ts | Persists update-time recategorization and handles duplicate checks and uniqueness races consistently. |
| packages/plugin/src/tools/ctx-memory/tools.test.ts | Adds coverage for category persistence, legacy stored paths, duplicate handling, rollback, and SQLite error-shape compatibility. |
| packages/plugin/src/hooks/magic-context/inject-compartments.ts | Includes escaped categories on ordinary update delta elements while excluding the internal visibility marker. |
| packages/pi-plugin/src/inject-compartments-pi.ts | Mirrors categorized update-delta rendering in the pi-plugin implementation. |
| crates/mc-module/src/memory_render.rs | Mirrors categorized update-delta rendering in Rust with XML attribute escaping and visibility-marker filtering. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[ctx_memory update] --> B[Load active memory]
    B --> C{Valid v2 category supplied?}
    C -->|Yes| D[Use supplied category]
    C -->|No| E[Keep stored category]
    D --> F[BEGIN IMMEDIATE]
    E --> F
    F --> G{Duplicate on stored path/category/hash?}
    G -->|Yes| H[Return friendly duplicate error]
    G -->|No| I[Update content, category, and hash]
    I --> J[Queue categorized mutation]
    J --> K[Commit]
    K --> L[Render updated element with category]
```
</details>

<sub>Reviews (5): Last reviewed commit: ["fix(ctx\_memory): recognize constraint er..."](https://github.com/cortexkit/magic-context/commit/b8a86489130cb44debb1bbc11995ee04a4e3f23d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=63238706)</sub>

<!-- /greptile_comment -->